### PR TITLE
Detect removable media in per-user udisks2 mount directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1617,6 +1617,7 @@ if(BUILD_TESTING)
     src/test/sqliteliketest.cpp
     src/test/synccontroltest.cpp
     src/test/synctrackmetadatatest.cpp
+    src/test/systemsettings_test.cpp
     src/test/tableview_test.cpp
     src/test/taglibtest.cpp
     src/test/touchscrollfilter_test.cpp

--- a/src/preferences/systemsettings.cpp
+++ b/src/preferences/systemsettings.cpp
@@ -259,11 +259,22 @@ QStringList SystemSettings::removableRoots() {
     // These mirror the roots the Rekordbox library feature uses to find USB
     // devices (rekordboxfeature.cpp), so anything the user sees in the browser
     // sidebar is enumerated here too.
-    return QStringList{
+    QStringList roots{
             QStringLiteral("/media"),
             QStringLiteral("/run/media"),
             QStringLiteral("/mnt"),
     };
+
+    // Desktop automounters such as udisks2 mount removable filesystems below
+    // a per-user directory. Keep the base roots for appliance configurations
+    // that mount drives directly below /media or /run/media, and only add the
+    // user roots when USER is available to avoid scanning the same paths twice.
+    const QString user = QString::fromLocal8Bit(qgetenv("USER"));
+    if (!user.isEmpty()) {
+        roots.append(QStringLiteral("/media/") + user);
+        roots.append(QStringLiteral("/run/media/") + user);
+    }
+    return roots;
 }
 
 // static

--- a/src/test/systemsettings_test.cpp
+++ b/src/test/systemsettings_test.cpp
@@ -1,0 +1,51 @@
+#include "preferences/systemsettings.h"
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QStringList>
+
+namespace {
+
+class ScopedUserEnvironment {
+  public:
+    explicit ScopedUserEnvironment(const QByteArray& user)
+            : m_wasSet(qEnvironmentVariableIsSet("USER")),
+              m_previous(qgetenv("USER")) {
+        qputenv("USER", user);
+    }
+
+    ~ScopedUserEnvironment() {
+        if (m_wasSet) {
+            qputenv("USER", m_previous);
+        } else {
+            qunsetenv("USER");
+        }
+    }
+
+  private:
+    bool m_wasSet;
+    QByteArray m_previous;
+};
+
+TEST(SystemSettingsTest, RemovableRootsIncludeCurrentUserMountDirectories) {
+    const ScopedUserEnvironment user("bitedj-test-user");
+
+    const QStringList roots = SystemSettings::removableRoots();
+
+    EXPECT_TRUE(roots.contains(QStringLiteral("/media/bitedj-test-user")));
+    EXPECT_TRUE(roots.contains(QStringLiteral("/run/media/bitedj-test-user")));
+}
+
+TEST(SystemSettingsTest, RemovableRootsDoNotDuplicateBasePathsWithoutUser) {
+    const ScopedUserEnvironment user("");
+
+    const QStringList roots = SystemSettings::removableRoots();
+
+    EXPECT_EQ(1, roots.count(QStringLiteral("/media")));
+    EXPECT_EQ(1, roots.count(QStringLiteral("/run/media")));
+    EXPECT_FALSE(roots.contains(QStringLiteral("/media/")));
+    EXPECT_FALSE(roots.contains(QStringLiteral("/run/media/")));
+}
+
+} // namespace


### PR DESCRIPTION
This adds support for removable filesystems mounted by udisks2 under per-user directories such as:

- `/media/$USER/<volume>`
- `/run/media/$USER/<volume>`

The existing USB mount enumeration scans only one directory level below `/media`, `/run/media`, and `/mnt`. In a standard per-user udisks2 layout, that level contains the username rather than the mounted volume, so the actual USB filesystem is not discovered by BiteDJ's USB management and recording features.

## Changes

- Add `/media/$USER` and `/run/media/$USER` to the removable-media roots when `$USER` is available.
- Preserve the existing base roots for appliance configurations that mount volumes directly below `/media`, `/run/media`, or `/mnt`.
- Avoid adding malformed paths such as `/media/` when `$USER` is unset or empty.
- Add unit tests covering both populated and empty `$USER` environments.

## Testing

- Built successfully in the existing Release configuration on Raspberry Pi OS.
- Verified with an HFS+ USB volume mounted under `/media/$USER/<volume>`.
- Confirmed that BiteDJ detects the volume after adding the per-user mount root.
- Confirmed that the existing direct-mount roots remain present.

## Additional context

Arch Linux and other distributions commonly mount removable filesystems through udisks2 at `/run/media/$USER/<volume>`. Raspberry Pi OS may use `/media/$USER/<volume>`. Supporting both layouts makes the USB enumeration independent of that distribution-specific base directory while retaining compatibility with BiteDJ appliance images that use direct mount points.
