### PR TITLE
fix(controller): target Effect1 for DDJ-400 Beat FX

### DIFF
--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -201,7 +201,6 @@ PioneerDDJ400.init = function() {
     for (let i = 1; i <= 3; i++) {
         engine.makeConnection("[EffectRack1_EffectUnit1_Effect" + i +"]", "enabled", PioneerDDJ400.toggleFxLight);
     }
-    engine.makeConnection("[EffectRack1_EffectUnit1]", "focused_effect", PioneerDDJ400.toggleFxLight);
 
     // Bite DJ: jog mode is chosen in the in-skin General settings tab via the
     // [BiteDJ],vinyl_mode CO (1 = Vinyl/scratch, 0 = CDJ/pitch-bend). Subscribe
@@ -269,9 +268,11 @@ PioneerDDJ400.toggleFxLight = function(_value, _group, _control) {
     PioneerDDJ400.toggleLight(PioneerDDJ400.lights.shiftBeatFx, enabled);
 };
 
+// Bite DJ skin only renders one effect slot (Effect1), so all BEAT FX
+// controls operate on it directly rather than on Mixxx's per-chain
+// "focused_effect" slot-cycling mechanism.
 PioneerDDJ400.focusedFxGroup = function() {
-    const focusedFx = engine.getValue("[EffectRack1_EffectUnit1]", "focused_effect");
-    return "[EffectRack1_EffectUnit1_Effect" + focusedFx + "]";
+    return "[EffectRack1_EffectUnit1_Effect1]";
 };
 
 PioneerDDJ400.beatFxLevelDepthRotate = function(_channel, _control, value) {


### PR DESCRIPTION
## Summary

FX and Beat FX controls did not work correctly with the DDJ-400 because the
mapping could target an effect slot that is not shown in BiteDJ.

Update the DDJ-400 mapping to always use Effect1, matching the existing
DDJ-FLX4 mapping.

## Changes

- Make `PioneerDDJ400.focusedFxGroup()` always return Effect1.
- Remove the unused `focused_effect` LED connection.

## Testing

Tested on a Raspberry Pi running BiteDJ with a physical DDJ-400.

- Beat FX SELECT changes the effect shown in BiteDJ.
- The Beat FX LED follows the Effect1 enabled state.
