### PR TITLE
Add Pioneer-style Memory Cue controls

### DIFF
--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -27,14 +27,13 @@
 //                SHIFT + LEVEL/DEPTH controls the Meta knob of the focused Effect
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
 //      * Loop Section:
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -528,13 +527,33 @@ PioneerDDJ400.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJ400.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJ400.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJ400.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJ400.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -536,7 +536,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJ400.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -546,9 +546,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJ400.quickJumpBack</key>
+                <key>PioneerDDJ400.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -557,7 +557,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJ400.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -567,9 +567,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJ400.quickJumpBack</key>
+                <key>PioneerDDJ400.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -578,7 +578,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJ400.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -588,9 +588,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJ400.quickJumpForward</key>
+                <key>PioneerDDJ400.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -599,7 +599,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJ400.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -609,9 +609,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJ400.quickJumpForward</key>
+                <key>PioneerDDJ400.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/controllers/Pioneer-DDJ-FLX2-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX2-script.js
@@ -29,14 +29,13 @@
 //                SHIFT + LEVEL/DEPTH controls the Meta knob of the focused Effect
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
 //      * Loop Section:
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -529,13 +528,33 @@ PioneerDDJFLX2.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJFLX2.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJFLX2.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJFLX2.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJFLX2.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-FLX2.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX2.midi.xml
@@ -536,7 +536,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX2.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -546,9 +546,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX2.quickJumpBack</key>
+                <key>PioneerDDJFLX2.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -557,7 +557,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX2.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -567,9 +567,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX2.quickJumpBack</key>
+                <key>PioneerDDJFLX2.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -578,7 +578,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX2.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -588,9 +588,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX2.quickJumpForward</key>
+                <key>PioneerDDJFLX2.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -599,7 +599,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX2.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -609,9 +609,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX2.quickJumpForward</key>
+                <key>PioneerDDJFLX2.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -25,7 +25,7 @@
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
 //
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
@@ -33,7 +33,6 @@
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
 //
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -622,13 +621,33 @@ PioneerDDJFLX4.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJFLX4.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJFLX4.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJFLX4.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJFLX4.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -546,7 +546,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX4.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -556,9 +556,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <key>PioneerDDJFLX4.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -567,7 +567,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX4.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -577,9 +577,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <key>PioneerDDJFLX4.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -588,7 +588,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX4.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -598,9 +598,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <key>PioneerDDJFLX4.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -609,7 +609,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX4.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -619,9 +619,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <key>PioneerDDJFLX4.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/skins/BiteDJ/deck.xml
+++ b/res/skins/BiteDJ/deck.xml
@@ -528,7 +528,7 @@
               <TextColor>#c7b205</TextColor>
               <Align>top</Align>
             </Mark>
-            <!-- Memory cue bank (slots 17-24, chronological). Bottom-aligned
+            <!-- Memory cue bank (slots 17-26, chronological). Bottom-aligned
                  so a glance separates them from the hot cues on top; they sit
                  alongside CUE, which is memory cue 1. Keep in step with
                  kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
@@ -584,6 +584,20 @@
             <Mark>
               <Hotcue>24</Hotcue>
               <Text>M8</Text>
+              <Color>#9aa0a6</Color>
+              <TextColor>#9aa0a6</TextColor>
+              <Align>bottom</Align>
+            </Mark>
+            <Mark>
+              <Hotcue>25</Hotcue>
+              <Text>M9</Text>
+              <Color>#9aa0a6</Color>
+              <TextColor>#9aa0a6</TextColor>
+              <Align>bottom</Align>
+            </Mark>
+            <Mark>
+              <Hotcue>26</Hotcue>
+              <Text>M10</Text>
               <Color>#9aa0a6</Color>
               <TextColor>#9aa0a6</TextColor>
               <Align>bottom</Align>

--- a/res/skins/BiteDJ/templates/cue_deck_page.xml
+++ b/res/skins/BiteDJ/templates/cue_deck_page.xml
@@ -143,7 +143,7 @@
         </Connection>
       </WidgetGroup>
 
-      <!-- Memory cue bank: slots 17-24, chronological. Keep in step with
+      <!-- Memory cue bank: slots 17-26, chronological. Keep in step with
            kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
       <WidgetGroup>
         <ObjectName>CuePanel_Grid</ObjectName>
@@ -175,6 +175,11 @@
                 <SetVariable name="hotcue">20</SetVariable>
                 <SetVariable name="label">M4</SetVariable>
               </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">21</SetVariable>
+                <SetVariable name="label">M5</SetVariable>
+              </Template>
             </Children>
           </WidgetGroup>
           <WidgetGroup>
@@ -182,11 +187,6 @@
             <Layout>horizontal</Layout>
             <Size>0me,56f</Size>
             <Children>
-              <Template src="skin:templates/cue_pad.xml">
-                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
-                <SetVariable name="hotcue">21</SetVariable>
-                <SetVariable name="label">M5</SetVariable>
-              </Template>
               <Template src="skin:templates/cue_pad.xml">
                 <SetVariable name="channel"><Variable name="channel"/></SetVariable>
                 <SetVariable name="hotcue">22</SetVariable>
@@ -201,6 +201,16 @@
                 <SetVariable name="channel"><Variable name="channel"/></SetVariable>
                 <SetVariable name="hotcue">24</SetVariable>
                 <SetVariable name="label">M8</SetVariable>
+              </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">25</SetVariable>
+                <SetVariable name="label">M9</SetVariable>
+              </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">26</SetVariable>
+                <SetVariable name="label">M10</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>

--- a/res/skins/BiteDJ/templates/cue_pad.xml
+++ b/res/skins/BiteDJ/templates/cue_pad.xml
@@ -19,7 +19,7 @@
   Variables:
     channel: deck number.
     hotcue:  hotcue slot, 1-based.
-    label:   what the pad is called (A-H, M1-M8).
+    label:   what the pad is called (A-H, M1-M10).
 -->
 <Template>
   <HotcueButton>

--- a/res/skins/BiteDJ/waveform.xml
+++ b/res/skins/BiteDJ/waveform.xml
@@ -194,7 +194,7 @@
           <Align>top</Align>
         </Mark>
 
-        <!-- Memory cue bank (slots 17-24, chronological). Bottom-aligned to
+        <!-- Memory cue bank (slots 17-26, chronological). Bottom-aligned to
              separate them at a glance from the hot cues on top. Keep in step
              with kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
         <Mark>
@@ -249,6 +249,20 @@
         <Mark>
           <Hotcue>24</Hotcue>
           <Text>M8</Text>
+          <Color>#9aa0a6</Color>
+          <TextColor>#9aa0a6</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Hotcue>25</Hotcue>
+          <Text>M9</Text>
+          <Color>#9aa0a6</Color>
+          <TextColor>#9aa0a6</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Hotcue>26</Hotcue>
+          <Text>M10</Text>
           <Color>#9aa0a6</Color>
           <TextColor>#9aa0a6</TextColor>
           <Align>bottom</Align>

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1,5 +1,7 @@
 #include "engine/controls/cuecontrol.h"
 
+#include <algorithm>
+
 #include "control/controlindicator.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
@@ -201,6 +203,27 @@ void CueControl::createControls() {
     m_pHotcueFocusColorNext = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "hotcue_focus_color_next"));
 
+    m_pMemoryCueSet = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_set"));
+    m_pMemoryCueSet->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueDelete = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_delete"));
+    m_pMemoryCueDelete->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCuePrev = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_prev"));
+    m_pMemoryCuePrev->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueNext = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_next"));
+    m_pMemoryCueNext->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueSelected = std::make_unique<ControlObject>(
+        ConfigKey(m_group, "memorycue_selected"));
+    m_pMemoryCueSelected->setReadOnly();
+    m_pMemoryCueSelected->forceSet(0.0);
+    m_pMemoryCueCount =
+        std::make_unique<ControlObject>(ConfigKey(m_group, "memorycue_count"));
+    m_pMemoryCueCount->setReadOnly();
+    m_pMemoryCueCount->forceSet(0.0);
+
     // Create hotcue controls
     for (int i = 0; i < m_iNumHotCues; ++i) {
         HotcueControl* pControl = new HotcueControl(m_group, i);
@@ -334,6 +357,15 @@ void CueControl::connectControls() {
             &CueControl::hotcueFocusColorNext,
             Qt::DirectConnection);
 
+    connect(m_pMemoryCueSet.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueSet, Qt::DirectConnection);
+    connect(m_pMemoryCueDelete.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueDelete, Qt::DirectConnection);
+    connect(m_pMemoryCuePrev.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCuePrev, Qt::DirectConnection);
+    connect(m_pMemoryCueNext.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueNext, Qt::DirectConnection);
+
     // Hotcue controls
     for (const auto& pControl : std::as_const(m_hotcueControls)) {
         connect(pControl, &HotcueControl::hotcuePositionChanged,
@@ -420,6 +452,10 @@ void CueControl::disconnectControls() {
 
     disconnect(m_pHotcueFocusColorPrev.get(), nullptr, this, nullptr);
     disconnect(m_pHotcueFocusColorNext.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueSet.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueDelete.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCuePrev.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueNext.get(), nullptr, this, nullptr);
 
     for (const auto& pControl : std::as_const(m_hotcueControls)) {
         disconnect(pControl, nullptr, this, nullptr);
@@ -493,6 +529,8 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         m_pOutroEndEnabled->forceSet(0.0);
         m_n60dBSoundStartPosition.setValue(Cue::kNoPosition);
         setHotcueFocusIndex(Cue::kNoHotCue);
+        setSelectedMemoryCue(nullptr);
+        m_pMemoryCueCount->forceSet(0.0);
         m_pLoadedTrack.reset();
         m_usedSeekOnLoadPosition.setValue(mixxx::audio::kStartFramePos);
     }
@@ -526,6 +564,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 
     // Update COs with cues from track.
     loadCuesFromTrack();
+    setSelectedMemoryCue(nullptr);
 
     // Seek track according to SeekOnLoadMode.
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
@@ -758,6 +797,7 @@ void CueControl::loadCuesFromTrack() {
     DEBUG_ASSERT(mainCuePosition.isValid());
     const auto quantizedMainCuePosition = quantizeCuePoint(mainCuePosition);
     m_pCuePoint->set(quantizedMainCuePosition.toEngineSamplePosMaybeInvalid());
+    updateMemoryCueState();
 }
 
 void CueControl::trackAnalyzed() {
@@ -1256,6 +1296,200 @@ void CueControl::hotcueClear(HotcueControl* pControl, double value) {
     detachCue(pControl);
     m_pLoadedTrack->removeCue(pCue);
     setHotcueFocusIndex(Cue::kNoHotCue);
+    updateMemoryCueState();
+}
+
+QList<HotcueControl *> CueControl::memoryCueControlsInPositionOrder() const {
+  QList<HotcueControl *> controls;
+  const int end = mixxx::kMemoryCueBankStart + mixxx::kMemoryCueBankSize;
+  for (int hotcueIndex = mixxx::kMemoryCueBankStart; hotcueIndex < end;
+       ++hotcueIndex) {
+    HotcueControl *pControl = m_hotcueControls.value(hotcueIndex, nullptr);
+    if (pControl && pControl->getPosition().isValid()) {
+      controls.append(pControl);
+    }
+  }
+  std::sort(controls.begin(), controls.end(),
+            [](const auto *pLeft, const auto *pRight) {
+              return pLeft->getPosition() < pRight->getPosition();
+            });
+  return controls;
+}
+
+HotcueControl *
+CueControl::memoryCueAtPosition(mixxx::audio::FramePos position) const {
+  if (!position.isValid()) {
+    return nullptr;
+  }
+
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  for (HotcueControl *pControl : controls) {
+    // FramePos is expressed in audio frames. Treat sub-frame differences as
+    // the same point so rounding at the engine-sample boundary is harmless.
+    if (fabs(pControl->getPosition() - position) < 0.5) {
+      return pControl;
+    }
+  }
+  return nullptr;
+}
+
+void CueControl::setMemoryCueAtMainCue(HotcueControl *pControl, double value,
+                                       mixxx::audio::FramePos position) {
+  auto lock = lockMutex(&m_trackMutex);
+  if (!m_pLoadedTrack || !position.isValid()) {
+    return;
+  }
+
+  hotcueClear(pControl, value);
+
+  const int hotcueIndex = pControl->getHotcueIndex();
+  mixxx::RgbColor color = mixxx::PredefinedColorPalettes::kDefaultCueColor;
+  ConfigKey autoHotcueColorsKey("[Controls]", "auto_hotcue_colors");
+  if (getConfig()->getValue(autoHotcueColorsKey, false)) {
+    color = m_colorPaletteSettings.getHotcueColorPalette().colorForHotcueIndex(
+        hotcueIndex);
+  } else {
+    color = colorFromConfig(ConfigKey("[Controls]", "HotcueDefaultColorIndex"));
+  }
+
+  CuePointer pCue = m_pLoadedTrack->createAndAddCue(
+      mixxx::CueType::HotCue, hotcueIndex, position,
+      mixxx::audio::kInvalidFramePos, color);
+  attachCue(pCue, pControl);
+}
+
+void CueControl::setSelectedMemoryCue(HotcueControl *pControl) {
+  if (pControl) {
+    const int hotcueIndex = pControl->getHotcueIndex();
+    VERIFY_OR_DEBUG_ASSERT(hotcueIndex >= mixxx::kMemoryCueBankStart &&
+                           hotcueIndex < mixxx::kMemoryCueBankStart +
+                                             mixxx::kMemoryCueBankSize) {
+      return;
+    }
+    m_selectedMemoryCueIndex = hotcueIndex;
+    m_pMemoryCueSelected->forceSet(hotcueIndex - mixxx::kMemoryCueBankStart +
+                                   1);
+  } else {
+    m_selectedMemoryCueIndex = Cue::kNoHotCue;
+    m_pMemoryCueSelected->forceSet(0.0);
+  }
+}
+
+void CueControl::updateMemoryCueState() {
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  m_pMemoryCueCount->forceSet(controls.size());
+  if (m_selectedMemoryCueIndex == Cue::kNoHotCue) {
+    return;
+  }
+  HotcueControl *pSelected =
+      m_hotcueControls.value(m_selectedMemoryCueIndex, nullptr);
+  if (!pSelected || !pSelected->getPosition().isValid()) {
+    setSelectedMemoryCue(nullptr);
+  }
+}
+
+void CueControl::callAdjacentMemoryCue(int direction) {
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  if (controls.isEmpty()) {
+    setSelectedMemoryCue(nullptr);
+    return;
+  }
+
+  const mixxx::audio::FramePos currentPosition = frameInfo().currentPosition;
+  if (!currentPosition.isValid()) {
+    return;
+  }
+
+  HotcueControl *pTarget = nullptr;
+  if (direction > 0) {
+    for (HotcueControl *pControl : controls) {
+      if (pControl->getPosition() - currentPosition > 0.5) {
+        pTarget = pControl;
+        break;
+      }
+    }
+  } else {
+    for (auto it = controls.crbegin(); it != controls.crend(); ++it) {
+      if (currentPosition - (*it)->getPosition() > 0.5) {
+        pTarget = *it;
+        break;
+      }
+    }
+  }
+
+  // Do not wrap at either end of the track.
+  if (!pTarget) {
+    return;
+  }
+  setSelectedMemoryCue(pTarget);
+  // Memory Cue CALL is a head-positioning operation, not a performance
+  // trigger: stop and seek exactly instead of using hotcue_activate.
+  hotcueGotoAndStop(pTarget, 1.0);
+}
+
+void CueControl::memoryCueSet(double value) {
+  if (value <= 0) {
+    return;
+  }
+
+  const bool loopEnabled = m_pLoopEnabled->toBool();
+  const mixxx::audio::FramePos position =
+      loopEnabled ? mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        m_pLoopStartPosition->get())
+                  : mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        m_pCuePoint->get());
+  if (!position.isValid()) {
+    return;
+  }
+  if (memoryCueAtPosition(position)) {
+    return;
+  }
+
+  const int end = mixxx::kMemoryCueBankStart + mixxx::kMemoryCueBankSize;
+  for (int hotcueIndex = mixxx::kMemoryCueBankStart; hotcueIndex < end;
+       ++hotcueIndex) {
+    HotcueControl *pControl = m_hotcueControls.value(hotcueIndex, nullptr);
+    if (pControl && pControl->getStatus() == HotcueControl::Status::Empty) {
+      if (loopEnabled) {
+        hotcueSet(pControl, value, HotcueSetMode::Loop);
+      } else {
+        setMemoryCueAtMainCue(pControl, value, position);
+      }
+      // Storing a Memory Cue does not CALL it. Leave navigation unselected so
+      // the next CALL is not constrained by the newly stored cue's bank slot.
+      setSelectedMemoryCue(nullptr);
+      updateMemoryCueState();
+      return;
+    }
+  }
+}
+
+void CueControl::memoryCueDelete(double value) {
+  if (value <= 0) {
+    return;
+  }
+
+  HotcueControl *pControl = memoryCueAtPosition(frameInfo().currentPosition);
+  if (!pControl) {
+    setSelectedMemoryCue(nullptr);
+    return;
+  }
+  setSelectedMemoryCue(pControl);
+  hotcueClear(pControl, value);
+  setSelectedMemoryCue(nullptr);
+  updateMemoryCueState();
+}
+
+void CueControl::memoryCuePrev(double value) {
+  if (value > 0) {
+    callAdjacentMemoryCue(-1);
+  }
+}
+
+void CueControl::memoryCueNext(double value) {
+  if (value > 0) {
+    callAdjacentMemoryCue(1);
+  }
 }
 
 void CueControl::hotcuePositionChanged(

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -241,6 +241,11 @@ class CueControl : public EngineControl {
     void hotcueFocusColorNext(double v);
     void hotcueFocusColorPrev(double v);
 
+    void memoryCueSet(double v);
+    void memoryCueDelete(double v);
+    void memoryCuePrev(double v);
+    void memoryCueNext(double v);
+
     void passthroughChanged(double v);
 
     void cueSet(double v);
@@ -298,6 +303,13 @@ class CueControl : public EngineControl {
     void seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition);
     void setHotcueFocusIndex(int hotcueIndex);
     int getHotcueFocusIndex() const;
+    QList<HotcueControl *> memoryCueControlsInPositionOrder() const;
+    HotcueControl *memoryCueAtPosition(mixxx::audio::FramePos position) const;
+    void setMemoryCueAtMainCue(HotcueControl *pControl, double value,
+                               mixxx::audio::FramePos position);
+    void callAdjacentMemoryCue(int direction);
+    void setSelectedMemoryCue(HotcueControl *pControl);
+    void updateMemoryCueState();
     mixxx::RgbColor colorFromConfig(const ConfigKey& configKey);
 
     UserSettingsPointer m_pConfig;
@@ -372,6 +384,16 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlObject> m_pHotcueFocus;
     std::unique_ptr<ControlPushButton> m_pHotcueFocusColorNext;
     std::unique_ptr<ControlPushButton> m_pHotcueFocusColorPrev;
+
+    // Pioneer-style navigation over the reserved hotcue_17..26 storage bank.
+    // Keeping the storage compatible with Mixxx avoids a CueType/DB fork.
+    std::unique_ptr<ControlPushButton> m_pMemoryCueSet;
+    std::unique_ptr<ControlPushButton> m_pMemoryCueDelete;
+    std::unique_ptr<ControlPushButton> m_pMemoryCuePrev;
+    std::unique_ptr<ControlPushButton> m_pMemoryCueNext;
+    std::unique_ptr<ControlObject> m_pMemoryCueSelected;
+    std::unique_ptr<ControlObject> m_pMemoryCueCount;
+    int m_selectedMemoryCueIndex{Cue::kNoHotCue};
 
     parented_ptr<ControlProxy> m_pPassthrough;
 

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -40,6 +40,27 @@ class HotcueControlTest : public BaseSignalPathTest {
         m_pHotcue2Status = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_status");
         m_pHotcue2Position = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_position");
         m_pHotcue2EndPosition = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_endposition");
+        m_pMemoryCue17Status =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_17_status");
+        m_pMemoryCue17Position =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_17_position");
+        m_pMemoryCue18Status =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_18_status");
+        m_pMemoryCue18Position =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_18_position");
+        m_pMemoryCueSet =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_set");
+        m_pMemoryCueDelete =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_delete");
+        m_pMemoryCuePrev =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_prev");
+        m_pMemoryCueNext =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_next");
+        m_pMemoryCueSelected =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_selected");
+        m_pMemoryCueCount =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_count");
+        m_pCueSet = std::make_unique<ControlProxy>(m_sGroup1, "cue_set");
         m_pQuantizeEnabled = std::make_unique<ControlProxy>(m_sGroup1, "quantize");
     }
 
@@ -118,8 +139,170 @@ class HotcueControlTest : public BaseSignalPathTest {
     std::unique_ptr<ControlProxy> m_pHotcue2Status;
     std::unique_ptr<ControlProxy> m_pHotcue2Position;
     std::unique_ptr<ControlProxy> m_pHotcue2EndPosition;
+    std::unique_ptr<ControlProxy> m_pMemoryCue17Status;
+    std::unique_ptr<ControlProxy> m_pMemoryCue17Position;
+    std::unique_ptr<ControlProxy> m_pMemoryCue18Status;
+    std::unique_ptr<ControlProxy> m_pMemoryCue18Position;
+    std::unique_ptr<ControlProxy> m_pMemoryCueSet;
+    std::unique_ptr<ControlProxy> m_pMemoryCueDelete;
+    std::unique_ptr<ControlProxy> m_pMemoryCuePrev;
+    std::unique_ptr<ControlProxy> m_pMemoryCueNext;
+    std::unique_ptr<ControlProxy> m_pMemoryCueSelected;
+    std::unique_ptr<ControlProxy> m_pMemoryCueCount;
+    std::unique_ptr<ControlProxy> m_pCueSet;
     std::unique_ptr<ControlProxy> m_pQuantizeEnabled;
 };
+
+TEST_F(HotcueControlTest, MemoryCueCallUsesPositionOrderAndStops) {
+  TrackPointer pTrack = createTestTrack();
+  const mixxx::audio::FramePos earlyPosition(3000);
+  const mixxx::audio::FramePos latePosition(9000);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue, mixxx::kMemoryCueBankStart,
+                          latePosition, mixxx::audio::kInvalidFramePos);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue,
+                          mixxx::kMemoryCueBankStart + 1, earlyPosition,
+                          mixxx::audio::kInvalidFramePos);
+  loadTrack(pTrack);
+
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  m_pPlay->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_FALSE(m_pPlay->toBool());
+  EXPECT_EQ(earlyPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(latePosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueSelected->get());
+
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(earlyPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+}
+
+TEST_F(HotcueControlTest, MemoryCueCallUsesCurrentPositionWithSingleCue) {
+  TrackPointer pTrack = createTestTrack();
+  const mixxx::audio::FramePos cuePosition(5000);
+  const mixxx::audio::FramePos beforePosition(1000);
+  const mixxx::audio::FramePos afterPosition(9000);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue, mixxx::kMemoryCueBankStart,
+                          cuePosition, mixxx::audio::kInvalidFramePos);
+  loadTrack(pTrack);
+
+  setCurrentFramePosition(afterPosition);
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(cuePosition, currentFramePosition());
+
+  setCurrentFramePosition(beforePosition);
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(cuePosition, currentFramePosition());
+
+  setCurrentFramePosition(afterPosition);
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(afterPosition, currentFramePosition());
+
+  setCurrentFramePosition(beforePosition);
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(beforePosition, currentFramePosition());
+}
+
+TEST_F(HotcueControlTest, MemoryCueSetAndDeleteUseReservedBank) {
+  createAndLoadFakeTrack();
+  const mixxx::audio::FramePos cuePosition(5000);
+  const mixxx::audio::FramePos playPosition(9000);
+  setCurrentFramePosition(cuePosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  setCurrentFramePosition(playPosition);
+
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue17Status->get());
+  EXPECT_EQ(cuePosition.toEngineSamplePos(), m_pMemoryCue17Position->get());
+  EXPECT_EQ(playPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  setCurrentFramePosition(cuePosition);
+  m_pMemoryCueDelete->set(1.0);
+  ProcessBuffer();
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+                   m_pMemoryCue17Status->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+}
+
+TEST_F(HotcueControlTest,
+       MemoryCueSetAtExistingPositionDoesNotDuplicateAndDeleteUsesPosition) {
+  createAndLoadFakeTrack();
+  const mixxx::audio::FramePos firstPosition(5000);
+  const mixxx::audio::FramePos secondPosition(9000);
+
+  setCurrentFramePosition(firstPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(0.0);
+
+  setCurrentFramePosition(secondPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(0.0);
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  // Select the second cue through CALL, then return to the first cue position.
+  // A duplicate SET must not adopt the first cue as the selection.
+  setCurrentFramePosition(mixxx::audio::FramePos(12000));
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(secondPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+
+  setCurrentFramePosition(firstPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  // A duplicate SET is a no-op, including the prior selection state.
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+  EXPECT_EQ(firstPosition.toEngineSamplePos(), m_pMemoryCue17Position->get());
+  EXPECT_EQ(secondPosition.toEngineSamplePos(), m_pMemoryCue18Position->get());
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue18Status->get());
+
+  m_pMemoryCueDelete->set(1.0);
+  ProcessBuffer();
+  // DELETE resolves its target from the current position, not the previously
+  // selected memory cue.
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+                   m_pMemoryCue17Status->get());
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue18Status->get());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueCount->get());
+
+  // DELETE clears the selection, but NEXT still resolves from the deleted
+  // cue's position and reaches the remaining cue.
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(secondPosition, currentFramePosition());
+}
 
 TEST_F(HotcueControlTest, DefautltControlValues) {
     TrackPointer pTrack = createTestTrack();

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -38,15 +38,17 @@ static constexpr int kFirstHotCueIndex = 0;
 /// `hotcue_N_*` controls, so the engine treats them identically; only the
 /// importer and the skin care which bank a cue lives in.
 ///
-/// Hot cue bank: rekordbox pads A-H, and the eight pads a controller maps.
+/// Hot cue bank: rekordbox pads A-P. Controllers with eight physical pads
+/// address A-H directly while the remaining slots stay available to the
+/// library, waveform and mappings that provide a second page.
 static constexpr int kHotCueBankStart = kFirstHotCueIndex;
-static constexpr int kHotCueBankSize = 8;
+static constexpr int kHotCueBankSize = 16;
 
 /// Memory cue bank: chronological, the first of which also becomes the main
 /// cue. Starts clear of the hot cue bank so that growing one never shifts the
 /// other.
 static constexpr int kMemoryCueBankStart = 16;
-static constexpr int kMemoryCueBankSize = 8;
+static constexpr int kMemoryCueBankSize = 10;
 
 // DTO for Cue information without dependencies on the actual Track object
 class CueInfo {


### PR DESCRIPTION
## Summary

This PR adds Pioneer-style Memory Cue behavior while keeping Memory Cues
separate from performance-oriented Hot Cues.

It changes the CUE/LOOP CALL buttons, which are currently assigned to Beat
Jump, to their original Memory Cue function.

It adds engine controls for storing, deleting, and calling Memory Cues; maps
those controls on the DDJ-400, DDJ-FLX2, and DDJ-FLX4; and expands the BiteDJ
Memory Cue UI from 8 to 10 slots.

## Memory Cues and Hot Cues are different features

Although both features store track positions, they serve different workflows.

| | Hot Cue | Memory Cue |
|---|---|---|
| Primary purpose | Performance and immediate triggering | Track preparation and navigation |
| Identity | Fixed pad/slot such as A-P | Chronologically ordered cue point |
| How it is called | Directly press the assigned pad | Use CUE/LOOP CALL previous/next from the current playhead position |
| Playback behavior | May start or gate playback according to the existing Hot Cue behavior | Stops playback and positions the playhead at the cue |
| Order | Pad order is independent of track position | Searched in track-position order, independent of the internal storage slot |
| Loop support | A slot may contain a saved loop | Memory Loops are not supported by this PR |
| Display metadata | Per-slot color and label | Ordered Memory Cue number (`M1`-`M10` in the current UI) |
| Deletion in this PR | Delete the explicitly addressed Hot Cue slot | Delete the Memory Cue matching the current playhead position |

Keeping these semantics separate avoids making Pioneer CUE/LOOP CALL controls
behave like another page of performance pads.

## Storage layout: 16 Hot Cues and 10 Memory Cues

Mixxx already exposes a fixed set of `hotcue_N_*` controls and persists their
cue data. This PR partitions that existing storage instead of introducing a
new cue database type or schema:

- Hot Cue bank: slots 1-16 (`hotcue_1` through `hotcue_16`)
- Memory Cue bank: slots 17-26 (`hotcue_17` through `hotcue_26`)

Sixteen Hot Cues provide the A-P software bank while allowing controllers with
eight physical pads to continue addressing A-H directly and use a second page
when available.

Ten Memory Cues match the established Pioneer/rekordbox per-track Memory Cue
workflow and fit naturally into two rows of five in the BiteDJ Cue drawer.

The two banks have fixed, non-overlapping ranges. Expanding the Hot Cue bank
therefore does not renumber existing Memory Cue storage, and Memory Cues remain
compatible with the existing Mixxx cue persistence path.

This design intentionally reuses Hot Cue storage internally. The distinction
is made by the reserved bank and the dedicated Memory Cue controls; it does not
add a new `CueType` or database migration.

## Compatibility with other DJ software and USB libraries

The major DJ applications do not use a common Hot Cue capacity. The table
below compares their current per-track limits with the USB-library readers
available in BiteDJ/Mixxx as of August 2026.

| Source software | Hot Cue equivalent per track | Can BiteDJ/Mixxx read its exported USB library? | Notes |
|---|---:|---|---|
| Serato DJ Pro | 8 Cue Points | Yes | Mixxx detects removable Serato libraries and imports the Serato metadata stored with their tracks. |
| Traktor Pro | 8 mapped Hotcues | No | Traktor can store additional Cue Points and Loops, but only eight can be mapped as directly accessible Hotcues. Mixxx can read a desktop `collection.nml` from the standard local location, but it neither auto-detects a Traktor-exported USB library nor imports its Cue entries. |
| djay | 16 Cue Points | No | djay exposes Cue Points 1-8 and 9-16 as two pages. BiteDJ/Mixxx does not currently have a djay or OneLibrary USB reader. |
| Denon DJ / Engine DJ | 8 Hot Cues | No | Engine DJ also provides eight Saved Loops separately. BiteDJ/Mixxx does not currently read an Engine DJ USB database. |

References: [Serato Cue Points](https://support.serato.com/hc/en-us/articles/226518228-Cue-Points),
[Traktor CUE page](https://docs.native-instruments.com/ni-tech-manuals/traktor-pro-manual/en/traktor-overview),
[djay Cue Points](https://help.algoriddim.com/user-manual/djay-ios/dj-tools/cueing-looping/cues-points),
and [Engine DJ 5.0 User Guide](https://cdn.inmusicbrands.com/Software/ENDJ5/Engine%20DJ%20-%20User%20Guide%20-%20v5.0.0.pdf).

### Impact on this PR

This compatibility difference has little practical impact on this PR:

- Serato is the only one of these four formats currently read from removable
  media by BiteDJ/Mixxx. Its eight Cue Points fit entirely within the common
  Hot Cue 1-8 range and do not overlap the reserved Memory Cue range 17-26.
- Traktor USB libraries are not currently read. The existing local Traktor NML
  reader imports tracks, playlists, and basic metadata, but not Cue entries, so
  Traktor's eight-Hotcue mapping does not collide with this implementation.
- djay and Engine DJ USB libraries are not currently read, so their Cue limits
  do not affect the internal bank partition either.
- This PR does not add or change external-library export, conversion, or USB
  import behavior. It only partitions existing Mixxx cue storage inside
  BiteDJ.

If support for Traktor, djay/OneLibrary, or Engine DJ USB libraries is added in
the future, that work will need an explicit conversion policy. A reasonable
baseline would preserve Hot Cues 1-8 as the common interoperable range and
treat Hot Cues 9-16 as BiteDJ's extended range. That future conversion concern
does not require changing the 16-Hot-Cue/10-Memory-Cue layout in this PR.

## Behavior

The following Control Objects are added:

- `memorycue_set`
- `memorycue_delete`
- `memorycue_prev`
- `memorycue_next`
- `memorycue_selected` (read-only state)
- `memorycue_count` (read-only state)

SET behavior:

- The supported point-cue path requires a valid main Cue.
- Stores the main Cue position as a Memory Cue.
- Does nothing when a Memory Cue already exists at the target position.
- Clears the navigation selection after a successful SET.

CALL behavior:

- Searches by track position rather than internal slot number.
- Uses the current playhead position on every call.
- Stops playback and seeks exactly to the selected Memory Cue.
- Does not wrap at the beginning or end of the track.

DELETE behavior:

- Deletes the Memory Cue at the current playhead position.
- Does not delete a previously selected Memory Cue at a different position.
- Clears the selection after deletion.

### Out of scope: Memory Loops

This PR supports point Memory Cues only. It does **not** claim support for
storing, recalling, activating, or automatically triggering Memory Loops.

Because the implementation reuses Mixxx Hot Cue storage, pressing SET while a
loop is active can currently persist a Loop-type cue. However, CALL only stops
at its Loop In position; it does not restore and activate the complete saved
loop. This incidental partial behavior must not be treated as supported Memory
Loop functionality.

The expected demand for Memory Loops in BiteDJ and the required interaction
details, including Active Loop behavior, have not yet been established. Full
Memory Loop support should therefore be evaluated and implemented separately
in a future PR if there is sufficient demand.

## Controller mappings

The DDJ-400, DDJ-FLX2, and DDJ-FLX4 mappings use the same contextual behavior:

- CUE/LOOP CALL left:
  - active loop: halve the loop length
  - no active loop: call the previous Memory Cue
- CUE/LOOP CALL right:
  - active loop: double the loop length
  - no active loop: call the next Memory Cue
- SHIFT + left: delete the Memory Cue at the current position
- SHIFT + right: invoke Memory Cue SET

The loop-length and Memory Cue functions remain independent engine features.
Only these controller mappings select between them based on `loop_enabled`.
Controllers with dedicated loop-length buttons can map the controls separately
without this conditional behavior.

## UI

The existing BiteDJ Memory Cue drawer and waveform declarations are extended
from 8 to 10 Memory Cue slots. The drawer uses two rows of five so both rows
have equal pad widths.

### Out of scope: Pioneer-style downward-triangle markers

Pioneer-style Memory Cue markers are often shown as downward triangles above
the waveform. That visual change is deliberately **not included in this PR**.
It remains future design work and is outside the scope of this implementation.

This is a waveform rendering and visual-layer design issue, not a safe label
substitution. In the detailed waveform, the vertical cue line and label are
currently generated as one marker image. Replacing `M1`, `M2`, and so on with
a `▼` character produces a triangle inside the existing rectangular label and
does not provide the required draw priority relative to the play-position bar
and Hot Cue labels.

A correct implementation should separate cue lines from marker overlays and
define an explicit rendering order, for example:

1. cue position lines
2. play-position bar
3. Memory Cue markers
4. Hot Cue markers and labels

That renderer and skin design work should be handled as a separate follow-up.
This PR retains the existing `M1`-`M10` rectangular Memory Cue labels.

## Tests

The engine tests cover:

- chronological CALL ordering independent of storage slot order
- CALL behavior with a single Memory Cue and different playhead positions
- stopping playback when a Memory Cue is called
- storing at the main Cue rather than the current playhead
- duplicate SET behavior
- deleting by current position after a different cue was selected
- Memory Cue count and selected-state updates

The controller JavaScript and MIDI XML files were also checked for syntax and
XML validity. The implementation was built and the related test suites passed
on both the Debian development environment and the Raspberry Pi OS target.

## Upstream merge and maintenance considerations

This PR modifies Mixxx-derived core files, especially
`src/engine/controls/cuecontrol.cpp`, `cuecontrol.h`, `cueinfo.h`, and the Hot Cue
tests. Future upstream merges may require manual conflict resolution if Mixxx
changes the same control creation, signal connection, track-loading, or Hot Cue
management sections.

The risk is limited to overlapping hunks rather than the whole files, but
`CueControl` is active upstream code and should be treated as a likely merge
touchpoint.

The implementation reduces longer-term divergence by:

- reusing the existing cue model and `hotcue_N_*` persistence
- avoiding a new database schema or BiteDJ-only `CueType`
- defining bank boundaries in shared constants
- keeping device-specific button multiplexing in controller mappings
- covering the core behavior with focused tests

If this remains a long-lived BiteDJ-only patch, a future refactor could move
the bulk of the Memory Cue method definitions into a dedicated source file,
leaving only lifecycle integration in `CueControl`. That would reduce the size
of future conflicts, but it is not required for the current implementation.

## Verification

- C++ build completed successfully on Debian and Raspberry Pi OS.
- `HotcueControlTest.MemoryCue*`: 4 tests passed.
- `WaveformMarkSetTest.*`: 8 tests passed.
- JavaScript controller files passed syntax checks.
- Controller and skin XML files passed XML validation.
- `git diff --check` passed.
- Verified with a Pioneer DDJ-400 connected to the Raspberry Pi OS target.
