### PR TITLE
Update the default font to Inter with Noto fallbacks

### DIFF
--- a/res/skins/BiteDJ/style.qss
+++ b/res/skins/BiteDJ/style.qss
@@ -11,7 +11,7 @@
 }
 
 * {
-  font-family: 'Monospace';
+  font-family: 'Inter', sans-serif, 'Monospace';
 }
 
 QMenuBar, QMenuBar::item, QMenu, QMenu::item {


### PR DESCRIPTION
# Summary
This PR updates the default font stack to prefer Inter, followed by the system’s sans-serif fallback fonts.
Inter is visually very close to the typeface used on Pioneer DJ decks, so I believe it is a good fit for the default UI font.
The following font packages are assumed to be installed:
- fonts-inter provides the primary UI font.
- fonts-noto adds support for a wide range of languages and writing systems from around the world, including Thai and Arabic.
- fonts-noto-cjk adds support for Chinese, Japanese and Korean.
Specifying sans-serif as the fallback allows characters not covered by Inter to be rendered using an appropriate Noto font selected by the system.

# Screenshots
Screenshots showing the UI with this font configuration are attached below.

<img width="1279" height="599" alt="スクリーンショット 2026-08-24 18 52 32" src="https://github.com/user-attachments/assets/b2c054b6-a537-4f74-bd06-5c209d3293a4" />
<img width="1276" height="599" alt="スクリーンショット 2026-08-24 18 47 37" src="https://github.com/user-attachments/assets/b4e00a1f-dcf6-4690-b66f-01a6968d140b" />
