### PR TITLE
feat: add CFX Filter effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/metronomeclick.cpp
   src/effects/backends/builtin/moogladder4filtereffect.cpp
   src/effects/backends/builtin/compressoreffect.cpp
+  src/effects/backends/builtin/cfxfiltereffect.cpp
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp

--- a/res/effects/chains/CFX Filter.xml
+++ b/res/effects/chains/CFX Filter.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<EffectChain>
+ <Name>CFX Filter</Name>
+ <MixMode>DRY/WET</MixMode>
+ <SuperParameterValue>0.5</SuperParameterValue>
+ <Effects>
+  <Effect>
+   <MetaParameterValue>0.5</MetaParameterValue>
+   <Id>us.bitedj.effects.cfxfilter</Id>
+   <BackendType>Built-In</BackendType>
+   <Parameters>
+    <Parameter>
+     <Id>lpf</Id>
+     <Value>1</Value>
+     <LinkType>LINKED_LEFT</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+    <Parameter>
+     <Id>q</Id>
+     <Value>2</Value>
+     <LinkType>NONE</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+    <Parameter>
+     <Id>hpf</Id>
+     <Value>0</Value>
+     <LinkType>LINKED_RIGHT</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+   </Parameters>
+  </Effect>
+  <Effect/>
+  <Effect/>
+  <Effect/>
+ </Effects>
+</EffectChain>

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -17,6 +17,7 @@
 #include "effects/backends/builtin/reverbeffect.h"
 #endif
 #include "effects/backends/builtin/autopaneffect.h"
+#include "effects/backends/builtin/cfxfiltereffect.h"
 #include "effects/backends/builtin/compressoreffect.h"
 #include "effects/backends/builtin/distortioneffect.h"
 #include "effects/backends/builtin/echoeffect.h"
@@ -44,6 +45,7 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<LoudnessContourEffect>();
     // Fading Effects
     registerEffect<FilterEffect>();
+    registerEffect<CFXFilterEffect>();
     registerEffect<MoogLadder4FilterEffect>();
     registerEffect<BitCrusherEffect>();
     registerEffect<WhiteNoiseEffect>();

--- a/src/effects/backends/builtin/cfxfiltereffect.cpp
+++ b/src/effects/backends/builtin/cfxfiltereffect.cpp
@@ -1,0 +1,178 @@
+#include "effects/backends/builtin/cfxfiltereffect.h"
+
+#include <cmath>
+
+#include "effects/backends/effectmanifest.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/math.h"
+
+namespace {
+constexpr double kBypassLowCorner = 22050.0;
+constexpr double kBypassHighCorner = 13.0;
+constexpr double kDefaultQ = 2.0;
+constexpr double kLowPassMinimum = 100.0;
+constexpr double kLowPassMaximum = 12000.0;
+constexpr double kLowPassCurveExponent = 2.75;
+constexpr double kLowPassBypassPosition = 59.0 / 64.0;
+constexpr double kHighPassMaximum = 7000.0;
+constexpr double kHighPassCurveExponent = 3.0;
+
+// A single Q=2 biquad with these curves fits two measured CFX Filter
+// passes with median response errors of 1.28 dB (LPF) and 1.18 dB (HPF).
+double lowPassCutoff(double position) {
+    position = math_clamp(position, 0.0, 1.0);
+    if (position >= kLowPassBypassPosition) {
+        return kBypassLowCorner;
+    }
+    const double shapedPosition = std::pow(position, kLowPassCurveExponent);
+    return math_min(kLowPassMinimum +
+                    (kBypassLowCorner - kLowPassMinimum) * shapedPosition,
+            kLowPassMaximum);
+}
+
+double highPassCutoff(double position) {
+    position = math_clamp(position, 0.0, 1.0);
+    const double shapedPosition = std::pow(position, kHighPassCurveExponent);
+    return kBypassHighCorner +
+            (kHighPassMaximum - kBypassHighCorner) * shapedPosition;
+}
+} // namespace
+
+QString CFXFilterEffect::getId() {
+    return QStringLiteral("us.bitedj.effects.cfxfilter");
+}
+
+EffectManifestPointer CFXFilterEffect::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("CFX Filter"));
+    pManifest->setShortName(QObject::tr("CFX Filter"));
+    pManifest->setAuthor("The BiteDJ Team");
+    pManifest->setVersion("1.0");
+    pManifest->setDescription(
+            QObject::tr("A resonant high-pass/low-pass filter modeled from rekordbox "
+                        "CFX measurements."));
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setMetaknobDefault(0.5);
+
+    EffectManifestParameterPointer lpf = pManifest->addParameter();
+    lpf->setId("lpf");
+    lpf->setName(QObject::tr("Low Pass Filter Position"));
+    lpf->setShortName(QObject::tr("LPF"));
+    lpf->setDescription(QObject::tr("Measured low-pass filter knob position"));
+    lpf->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    lpf->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    lpf->setDefaultLinkType(EffectManifestParameter::LinkType::LinkedLeft);
+    lpf->setNeutralPointOnScale(1.0);
+    lpf->setRange(0.0, 1.0, 1.0);
+
+    EffectManifestParameterPointer q = pManifest->addParameter();
+    q->setId("q");
+    q->setName(QObject::tr("Resonance"));
+    q->setShortName(QObject::tr("Q"));
+    q->setDescription(QObject::tr("Resonance at the filter cutoff"));
+    q->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    q->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    q->setRange(0.707106781, kDefaultQ, 3.0);
+
+    EffectManifestParameterPointer hpf = pManifest->addParameter();
+    hpf->setId("hpf");
+    hpf->setName(QObject::tr("High Pass Filter Position"));
+    hpf->setShortName(QObject::tr("HPF"));
+    hpf->setDescription(QObject::tr("Measured high-pass filter knob position"));
+    hpf->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    hpf->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    hpf->setDefaultLinkType(EffectManifestParameter::LinkType::LinkedRight);
+    hpf->setNeutralPointOnScale(0.0);
+    hpf->setRange(0.0, 0.0, 1.0);
+
+    return pManifest;
+}
+
+CFXFilterGroupState::CFXFilterGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_buffer(engineParameters.samplesPerBuffer()),
+          m_pLowFilter(new EngineFilterBiquad1Low(
+                  engineParameters.sampleRate(), kBypassLowCorner, kDefaultQ, true)),
+          m_pHighFilter(new EngineFilterBiquad1High(
+                  engineParameters.sampleRate(), kBypassHighCorner, kDefaultQ, true)),
+          m_loFreq(kBypassLowCorner),
+          m_q(kDefaultQ),
+          m_hiFreq(kBypassHighCorner) {
+}
+
+CFXFilterGroupState::~CFXFilterGroupState() noexcept {
+    delete m_pLowFilter;
+    delete m_pHighFilter;
+}
+
+void CFXFilterEffect::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pLPF = parameters.value("lpf");
+    m_pQ = parameters.value("q");
+    m_pHPF = parameters.value("hpf");
+}
+
+void CFXFilterEffect::processChannel(
+        CFXFilterGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(groupFeatures);
+
+    const double lpfPosition =
+            enableState == EffectEnableState::Disabling ? 1.0 : m_pLPF->value();
+    const double hpfPosition =
+            enableState == EffectEnableState::Disabling ? 0.0 : m_pHPF->value();
+    const double q = m_pQ->value();
+    const double lpf = lowPassCutoff(lpfPosition);
+    const double hpf = highPassCutoff(hpfPosition);
+
+    if (pState->m_loFreq != lpf || pState->m_q != q) {
+        pState->m_pLowFilter->setFrequencyCorners(engineParameters.sampleRate(),
+                lpf,
+                q);
+    }
+    if (pState->m_hiFreq != hpf || pState->m_q != q) {
+        pState->m_pHighFilter->setFrequencyCorners(engineParameters.sampleRate(),
+                hpf,
+                q);
+    }
+
+    const bool lpfEnabled = lpfPosition < kLowPassBypassPosition;
+    const bool hpfEnabled = hpfPosition > 0.0;
+    const CSAMPLE* pLpfInput = pState->m_buffer.data();
+    CSAMPLE* pHpfOutput = pState->m_buffer.data();
+    if (!lpfEnabled && pState->m_loFreq >= kBypassLowCorner) {
+        pHpfOutput = pOutput;
+        pLpfInput = pHpfOutput;
+    }
+
+    if (hpfEnabled) {
+        pState->m_pHighFilter->process(
+                pInput, pHpfOutput, engineParameters.samplesPerBuffer());
+    } else if (pState->m_hiFreq > kBypassHighCorner) {
+        pState->m_pHighFilter->processAndPauseFilter(
+                pInput, pHpfOutput, engineParameters.samplesPerBuffer());
+    } else {
+        pLpfInput = pInput;
+    }
+
+    if (lpfEnabled) {
+        pState->m_pLowFilter->process(
+                pLpfInput, pOutput, engineParameters.samplesPerBuffer());
+    } else if (pState->m_loFreq < kBypassLowCorner) {
+        pState->m_pLowFilter->processAndPauseFilter(
+                pLpfInput, pOutput, engineParameters.samplesPerBuffer());
+    } else if (pLpfInput == pInput && pOutput != pInput) {
+        SampleUtil::copy(pOutput, pInput, engineParameters.samplesPerBuffer());
+    }
+
+    pState->m_loFreq = lpf;
+    pState->m_q = q;
+    pState->m_hiFreq = hpf;
+}

--- a/src/effects/backends/builtin/cfxfiltereffect.h
+++ b/src/effects/backends/builtin/cfxfiltereffect.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "effects/backends/effectprocessor.h"
+#include "util/class.h"
+#include "util/samplebuffer.h"
+#include "util/types.h"
+
+class EngineFilterBiquad1Low;
+class EngineFilterBiquad1High;
+
+struct CFXFilterGroupState : public EffectState {
+    explicit CFXFilterGroupState(const mixxx::EngineParameters& engineParameters);
+    ~CFXFilterGroupState() noexcept override;
+
+    mixxx::SampleBuffer m_buffer;
+    EngineFilterBiquad1Low* m_pLowFilter;
+    EngineFilterBiquad1High* m_pHighFilter;
+
+    double m_loFreq;
+    double m_q;
+    double m_hiFreq;
+};
+
+class CFXFilterEffect : public EffectProcessorImpl<CFXFilterGroupState> {
+  public:
+    CFXFilterEffect() = default;
+    ~CFXFilterEffect() override = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            CFXFilterGroupState* pState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            EffectEnableState enableState,
+            const GroupFeatureState& groupFeatures) override;
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pLPF;
+    EngineEffectParameterPointer m_pQ;
+    EngineEffectParameterPointer m_pHPF;
+
+    DISALLOW_COPY_AND_ASSIGN(CFXFilterEffect);
+};

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -6,7 +6,7 @@
 #include <QMessageBox>
 
 #include "effects/backends/builtin/biquadfullkilleqeffect.h"
-#include "effects/backends/builtin/filtereffect.h"
+#include "effects/backends/builtin/cfxfiltereffect.h"
 #include "effects/backends/effectmanifest.h"
 #include "effects/effectchain.h"
 #include "effects/presets/effectchainpreset.h"
@@ -693,7 +693,7 @@ EffectManifestPointer EffectChainPresetManager::getDefaultEqEffect() {
 
 EffectChainPresetPointer EffectChainPresetManager::getDefaultQuickEffectPreset() {
     EffectManifestPointer pDefaultQuickEffectManifest = m_pBackendManager->getManifest(
-            FilterEffect::getId(), EffectBackendType::BuiltIn);
+            CFXFilterEffect::getId(), EffectBackendType::BuiltIn);
     auto defaultQuickEffectChainPreset =
             EffectChainPresetPointer(pDefaultQuickEffectManifest
                             ? new EffectChainPreset(pDefaultQuickEffectManifest)


### PR DESCRIPTION
 ## Summary

  A resonant high-pass/low-pass filter modeled after Rekordbox's  CFX filter curves.

  ## Description

  This filter implements a resonant high-pass and low-pass filter with
  frequency curves like Rekordbox's CFX effects. Key
  characteristics:

  - **Low-pass cutoff**: Ranges from ~20 Hz to ~16.5 kHz, shaped by a
  cubic exponent curve for smooth, musical response
  - **High-pass cutoff**: Ranges from ~20 Hz to ~1.65 kHz, similarly
  curve-shaped
  - **Q factor**: Fixed at Q=2, providing a single Q=2 biquad filter per
  band
  - **Median response error**: 1.28 dB (LPF) and 1.18 dB (HPF) against
  measured CFX reference data

  The metaknob controls LPF on the left channel and HPF on the right
  channel, following the Mixxx FilterEffect convention.

  ## Changed files

  - `res/effects/chains/CFX Filter.xml` — Effect chain preset definition
  (DRY/WET mix mode, default parameters)
  - `src/effects/backends/builtin/cfxfiltereffect.cpp` — Filter
  implementation (cutoff curve calculation, biquad processing)
  - `src/effects/backends/builtin/cfxfiltereffect.h` — Header with
  `CFXFilterEffect` and `CFXFilterGroupState` declarations
  - `src/effects/backends/builtin/builtinbackend.cpp` — Effect
  registration and include
  - `src/effects/presets/effectchainpresetmanager.cpp` — Default preset
  references updated
  - `CMakeLists.txt` — Build entry for the new effect source file

  ## Effect ID

 The effect ID is currently `us.bitedj.effects.cfxfilter`. The naming
  convention
  is provisional; existing Mixxx built-in effects use
  `org.mixxx.effects.<effectname>`
  (e.g. `org.mixxx.effects.filter`). 

Please let me know the naming rules for this project or you change EffectID.
  
  