### PR TITLE
Add Time Mode switching

### DIFF
--- a/res/skins/BiteDJ/deck.xml
+++ b/res/skins/BiteDJ/deck.xml
@@ -133,6 +133,26 @@
                 <Elide>right</Elide>
                 <Channel><Variable name="channel"/></Channel>
               </TrackProperty>
+              <WidgetGroup>
+                <ObjectName>DeckHeaderTime</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>100max,20f</Size>
+                <Children>
+                  <NumberPos>
+                    <ObjectName>DeckHeaderTimeValue</ObjectName>
+                    <Size>100max,20f</Size>
+                    <TooltipId>track_time</TooltipId>
+                    <NumberOfDigits>6</NumberOfDigits>
+                    <TabularNumbers>true</TabularNumbers>
+                    <Channel><Variable name="channel"/></Channel>
+                  </NumberPos>
+                </Children>
+                <Connection>
+                  <ConfigKey>[Tab],overview</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                  <Transform><Not/></Transform>
+                </Connection>
+              </WidgetGroup>
             </Children>
           </WidgetGroup>
         </Children>
@@ -236,11 +256,44 @@
             <Layout>vertical</Layout>
             <Size>0me,0me</Size>
             <Children>
-              <Label>
+              <WidgetGroup>
                 <ObjectName>DeckTrackTimeTitle</ObjectName>
-                <Text>Time</Text>
                 <Size>200me,25f</Size>
-              </Label>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <Label>
+                    <ObjectName>DeckTrackTimeRemainLabel</ObjectName>
+                    <Text>REMAIN</Text>
+                    <Connection>
+                      <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
+                      <Transform>
+                        <IsEqual>0</IsEqual>
+                        <Not/>
+                      </Transform>
+                      <BindProperty>highlight</BindProperty>
+                    </Connection>
+                  </Label>
+                  <Label>
+                    <ObjectName>DeckTrackTimeSlashLabel</ObjectName>
+                    <Text>/</Text>
+                  </Label>
+                  <Label>
+                    <ObjectName>DeckTrackTimeTimeLabel</ObjectName>
+                    <Text>TIME</Text>
+                    <Connection>
+                      <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
+                      <Transform>
+                        <IsEqual>1</IsEqual>
+                        <Not/>
+                      </Transform>
+                      <BindProperty>highlight</BindProperty>
+                    </Connection>
+                  </Label>
+                  <Label>
+                    <Size>0me,0me</Size>
+                  </Label>
+                </Children>
+              </WidgetGroup>
               <WidgetGroup>
                 <ObjectName>DeckTrackTimeWrapper</ObjectName>
                 <Layout>horizontal</Layout>
@@ -260,11 +313,13 @@
                             <ObjectName>DeckTrackTimeMini</ObjectName>
                             <MaximumSize>150,-1</MaximumSize>
                             <Text>0:00.00</Text>
+                            <TabularNumbers>true</TabularNumbers>
                           </Label>
                           <Label>
                             <ObjectName>DeckTrackTime</ObjectName>
                             <MinimumSize>150,-1</MinimumSize>
                             <Text>0:00.00</Text>
+                            <TabularNumbers>true</TabularNumbers>
                           </Label>
                         </Children>
                       </SizeAwareStack>
@@ -286,6 +341,7 @@
                             <MaximumSize>150,-1</MaximumSize>
                             <TooltipId>track_time</TooltipId>
                             <NumberOfDigits>6</NumberOfDigits>
+                            <TabularNumbers>true</TabularNumbers>
                             <Channel><Variable name="channel"/></Channel>
                             <Connection>
                               <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
@@ -300,6 +356,7 @@
                             <MinimumSize>150,-1</MinimumSize>
                             <TooltipId>track_time</TooltipId>
                             <NumberOfDigits>6</NumberOfDigits>
+                            <TabularNumbers>true</TabularNumbers>
                             <Channel><Variable name="channel"/></Channel>
                             <Connection>
                               <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
@@ -325,7 +382,7 @@
             <ObjectName>TrackBPMRangeContainer</ObjectName>
             <Layout>vertical</Layout>
             <Size>65max,40max</Size>
-            <Children>              
+            <Children>
               <WidgetGroup>
                 <ObjectName>DeckBPMRangePercent</ObjectName>
                 <Size>30me,16f</Size>
@@ -446,22 +503,6 @@
             <SignalMidColor>#007de1</SignalMidColor>
             <SignalHighColor>#007de1</SignalHighColor>
             <PlayedOverlayColor>#40ffffff</PlayedOverlayColor>
-            <!-- Time left in the track, drawn straight onto the summary as a
-                 watermark: centred and translucent enough to read the signal
-                 through. Scale is a share of the height the summary is
-                 *visible* over, which here is the container's 50px and not the
-                 widget's own 100px above — the strip deliberately shows the top
-                 half of a double-height overview, so a scale against the widget
-                 would centre the digits on the cut edge and lose their bottom
-                 half. This strip is what the settings/browse/sampler pages show
-                 of a deck, so it is the one place the countdown has to be
-                 readable from — on the Play page the scrolling waveform and the
-                 big Time readout are both on screen, so the watermark is off
-                 there (bound below). -->
-            <TimeRemainingAlign>center</TimeRemainingAlign>
-            <TimeRemainingColor>#fff</TimeRemainingColor>
-            <TimeRemainingOpacity>0.55</TimeRemainingOpacity>
-            <TimeRemainingScale>0.57</TimeRemainingScale>
             <Mark>
               <Control>cue_point</Control>
               <Color>#eb870f</Color>
@@ -607,15 +648,6 @@
             </MarkRange>
             <Connection>
               <ConfigKey>[Channel<Variable name="channel"/>],playposition</ConfigKey>
-            </Connection>
-            <!-- The watermark is off on the Play page, where the scrolling
-                 waveform and the Time readout already carry the countdown.
-                 Kept next to the connection above because setupConnections
-                 walks siblings from the first <Connection> on. -->
-            <Connection>
-              <ConfigKey>[Tab],overview</ConfigKey>
-              <BindProperty>timeRemainingVisible</BindProperty>
-              <Transform><Not/></Transform>
             </Connection>
           </Overview>
         </Children>

--- a/res/skins/BiteDJ/style.qss
+++ b/res/skins/BiteDJ/style.qss
@@ -161,10 +161,36 @@ WPushButton[value="1"]:hover {
   background-color: rgba(241, 89, 33, 0.12);
 }
 
-#DeckChannelTitle, #DeckTrackTimeTitle, #DeckTempoTitle {
+#DeckChannelTitle, #DeckTempoTitle,
+#DeckTrackTimeRemainLabel, #DeckTrackTimeSlashLabel, #DeckTrackTimeTimeLabel {
   font-size: 14px;
   font-weight: bold;
   text-transform: uppercase;
+}
+
+#DeckTrackTimeRemainLabel, #DeckTrackTimeTimeLabel {
+  color: #4a4a4a;
+}
+
+#DeckTrackTimeRemainLabel[highlight="1"],
+#DeckTrackTimeTimeLabel[highlight="1"] {
+  color: #e5e6ea;
+}
+
+#DeckTrackTimeSlashLabel {
+  color: #98989a;
+  padding: 0 1px;
+}
+
+#DeckHeaderTime {
+  qproperty-layoutAlignment: 'AlignRight | AlignVCenter';
+}
+
+#DeckHeaderTimeValue {
+  font-size: 18px;
+  font-weight: bold;
+  qproperty-alignment: 'AlignRight | AlignVCenter';
+  padding-right: 1px;
 }
 
 #DeckPlayingLeft, #DeckPlayingRight {

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -340,7 +340,9 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     m_pContext->setSkinBasePath(skinPath);
 
     if (m_pParent) {
-        qDebug() << "ERROR: Somehow a parent already exists -- you are probably re-using a LegacySkinParser which is not advisable!";
+        qDebug()
+                << "ERROR: Somehow a parent already exists -- you are probably "
+                   "reusing a LegacySkinParser which is not advisable!";
     }
     QDomElement skinDocument = openSkin(skinPath);
 
@@ -995,6 +997,8 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
     // effect which breaks color scheme support.
     pLabel->setup(element, *m_pContext);
     commonWidgetSetup(element, pLabel);
+    // OpenType features must be applied after the stylesheet selects the font.
+    pLabel->applyFontFeatures();
     pLabel->installEventFilter(m_pKeyboard);
     pLabel->installEventFilter(
             m_pControllerManager->getControllerLearningEventFilter());

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -2,6 +2,7 @@
 
 #include <QEvent>
 #include <QFont>
+#include <QtGlobal>
 
 #include "moc_wlabel.cpp"
 #include "skin/legacy/skincontext.h"
@@ -20,6 +21,7 @@ WLabel::WLabel(QWidget* pParent)
 
 void WLabel::setup(const QDomNode& node, const SkinContext& context) {
     m_scaleFactor = context.getScaleFactor();
+    m_bTabularNumbers = context.selectBool(node, "TabularNumbers", false);
 
     // Colors
     QPalette pal = palette(); // we have to copy out the palette to edit it since it's const (probably for threadsafety)
@@ -87,6 +89,19 @@ void WLabel::setup(const QDomNode& node, const SkinContext& context) {
                     "unknown, use right, middle, left or none.";
         }
     }
+}
+
+void WLabel::applyFontFeatures() {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    if (m_bTabularNumbers) {
+        // OpenType's "tnum" feature gives every digit the same advance width,
+        // preventing changing numeric text from shifting. Apply it after skin
+        // styling so the selected font keeps this feature.
+        QFont tabularFont = font();
+        tabularFont.setFeature("tnum", 1);
+        setFont(tabularFont);
+    }
+#endif
 }
 
 QString WLabel::text() const {

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -13,6 +13,7 @@ class WLabel : public QLabel, public WBaseWidget {
     explicit WLabel(QWidget* pParent=nullptr);
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
+    void applyFontFeatures();
 
     QString text() const;
     void setText(const QString& text);
@@ -38,6 +39,8 @@ class WLabel : public QLabel, public WBaseWidget {
     // Foreground and background colors.
     QColor m_qFgColor;
     QColor m_qBgColor;
+    bool m_bTabularNumbers{false};
+
   private:
     QString m_longText;
     Qt::TextElideMode m_elideMode;

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -1,5 +1,7 @@
 #include "widget/wnumberpos.h"
 
+#include <QMouseEvent>
+
 #include "control/controlproxy.h"
 #include "moc_wnumberpos.cpp"
 #include "util/duration.h"
@@ -26,6 +28,24 @@ WNumberPos::WNumberPos(const QString& group, QWidget* parent)
     m_pTimeFormat->connectValueChanged(
             this, &WNumberPos::slotSetTimeFormat);
     slotSetTimeFormat(m_pTimeFormat->get());
+}
+
+void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
+    bool leftClick = pEvent->buttons() & Qt::LeftButton;
+
+    if (leftClick) {
+        // Cycle through display modes
+        if (m_displayMode == TrackTime::DisplayMode::ELAPSED) {
+            m_displayMode = TrackTime::DisplayMode::REMAINING;
+        } else if (m_displayMode == TrackTime::DisplayMode::REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED_AND_REMAINING;
+        } else if (m_displayMode == TrackTime::DisplayMode::ELAPSED_AND_REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED;
+        }
+
+        m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
+        slotSetTimeElapsed(m_dOldTimeElapsed);
+    }
 }
 
 // Reimplementing WNumber::setValue

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -43,6 +43,12 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
             m_displayMode = TrackTime::DisplayMode::ELAPSED;
         }
 
+        // BiteDJ has a single track-time field, so skip Mixxx's combined
+        // elapsed-and-remaining mode without rewriting the upstream cycle.
+        if (m_displayMode == TrackTime::DisplayMode::ELAPSED_AND_REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED;
+        }
+
         m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
         slotSetTimeElapsed(m_dOldTimeElapsed);
     }

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -12,6 +12,9 @@ class WNumberPos : public WNumber {
   public:
     explicit WNumberPos(const QString& group, QWidget* parent = nullptr);
 
+  protected:
+    void mousePressEvent(QMouseEvent* pEvent) override;
+
   private slots:
     void setValue(double dValue) override;
     void slotSetTimeElapsed(double);

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -26,7 +26,6 @@ class WNumberPos : public WNumber {
 
     TrackTime::DisplayMode m_displayMode;
     TrackTime::DisplayFormat m_displayFormat;
-
     double m_dOldTimeElapsed;
     ControlProxy* m_pTimeElapsed;
     ControlProxy* m_pTimeRemaining;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -24,7 +24,6 @@
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
-#include "widget/timeremainingoverlay.h"
 #include "wskincolor.h"
 
 namespace {
@@ -74,18 +73,7 @@ WOverview::WOverview(
                   QStringLiteral("track_samples")),
           m_playpositionControl(
                   m_group,
-                  QStringLiteral("playposition")),
-          m_timeRemainingControl(
-                  m_group,
-                  QStringLiteral("time_remaining")),
-          m_timeRemainingColor(Qt::white),
-          m_timeRemainingBackgroundColor(
-                  0, 0, 0, TimeRemainingOverlay::kDefaultBackgroundAlpha),
-          m_timeRemainingOpacity(TimeRemainingOverlay::kDefaultOpacity),
-          m_timeRemainingScale(TimeRemainingOverlay::kDefaultScale),
-          m_timeRemainingAlign(Qt::AlignHCenter | Qt::AlignVCenter),
-          m_bTimeRemainingVisible(true),
-          m_iTimeRemainingSeconds(0) {
+                  QStringLiteral("playposition")) {
     m_endOfTrackControl = make_parented<ControlProxy>(
             m_group, QStringLiteral("end_of_track"), this, ControlFlag::NoAssertIfMissing);
     m_endOfTrackControl->connectValueChanged(this, &WOverview::onEndOfTrackChange);
@@ -167,36 +155,6 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
                 context.makeSkinPath(m_backgroundPixmapPath),
                 m_scaleFactor);
     }
-
-    // Time-remaining watermark. Defaults are in timeremainingoverlay.h; a skin
-    // only needs these nodes to deviate from them.
-    const QString timeRemainingColorName =
-            context.selectString(node, "TimeRemainingColor");
-    if (!timeRemainingColorName.isEmpty()) {
-        m_timeRemainingColor =
-                WSkinColor::getCorrectColor(QColor(timeRemainingColorName));
-    }
-    const QString timeRemainingBgColorName =
-            context.selectString(node, "TimeRemainingBgColor");
-    if (!timeRemainingBgColorName.isEmpty()) {
-        // Keep the alpha the skin asked for; getCorrectColor() would drop it.
-        m_timeRemainingBackgroundColor = QColor(timeRemainingBgColorName);
-    }
-    m_timeRemainingOpacity = math_clamp(
-            context.selectDouble(node,
-                    "TimeRemainingOpacity",
-                    TimeRemainingOverlay::kDefaultOpacity),
-            0.0,
-            1.0);
-    const double timeRemainingScale = context.selectDouble(node,
-            "TimeRemainingScale",
-            TimeRemainingOverlay::kDefaultScale);
-    if (timeRemainingScale > 0.0) {
-        m_timeRemainingScale = timeRemainingScale;
-    }
-    m_timeRemainingAlign = TimeRemainingOverlay::decodeAlign(
-            context.selectString(node, "TimeRemainingAlign"),
-            Qt::AlignHCenter | Qt::AlignVCenter);
 
     m_endOfTrackColor = QColor(200, 25, 20);
     const QString endOfTrackColorName = context.selectString(node, "EndOfTrackColor");
@@ -326,15 +284,6 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
     int oldPositionSeconds = m_iPosSeconds;
     m_iPosSeconds = static_cast<int>(dParameter * getTrackSamples());
     if ((m_bTimeRulerActive || m_pHoveredMark != nullptr) && oldPositionSeconds != m_iPosSeconds) {
-        redraw = true;
-    }
-
-    // The time-remaining watermark shows whole seconds, and on a short overview
-    // one pixel of play marker can span several of them. Redraw on the digits
-    // changing too, or the countdown would visibly skip.
-    const int oldTimeRemainingSeconds = m_iTimeRemainingSeconds;
-    m_iTimeRemainingSeconds = static_cast<int>(std::ceil(m_timeRemainingControl.get()));
-    if (m_bTimeRemainingVisible && oldTimeRemainingSeconds != m_iTimeRemainingSeconds) {
         redraw = true;
     }
 
@@ -736,8 +685,6 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
             drawTimeRuler(&painter);
             drawMarkLabels(&painter, offset, gain);
         }
-        // Last, so the watermark sits over every other layer.
-        drawTimeRemaining(&painter);
     }
 
     if (m_bPassthroughEnabled) {
@@ -1332,96 +1279,6 @@ void WOverview::drawMarkLabels(QPainter* pPainter, const float offset, const flo
             }
         }
     }
-}
-
-void WOverview::setTimeRemainingVisible(bool visible) {
-    if (m_bTimeRemainingVisible == visible) {
-        return;
-    }
-    m_bTimeRemainingVisible = visible;
-    update();
-}
-
-/// The part of the widget an ancestor doesn't cut off, in widget coordinates.
-/// A skin may hand the overview a widget taller than the room its container
-/// leaves it — deck.xml lays the summary out at double height and shows the
-/// top half of it — so the widget's own rect is not what the DJ can see. Only
-/// ancestor geometry is taken into account, not overlapping siblings: this
-/// decides where text is laid out, and that must not move when something else
-/// happens to be drawn over the strip.
-QRect WOverview::visibleStripRect() const {
-    QRect visible = rect();
-    for (const QWidget* pAncestor = parentWidget(); pAncestor != nullptr;
-            pAncestor = pAncestor->parentWidget()) {
-        visible &= pAncestor->rect().translated(-mapTo(pAncestor, QPoint(0, 0)));
-        if (pAncestor->isWindow()) {
-            break;
-        }
-    }
-    return visible;
-}
-
-void WOverview::drawTimeRemaining(QPainter* pPainter) {
-    if (!m_bTimeRemainingVisible) {
-        return;
-    }
-
-    const double remainingSeconds = m_timeRemainingControl.get();
-    if (remainingSeconds < 0.0) {
-        return;
-    }
-
-    const QRect visible = visibleStripRect();
-    if (visible.isEmpty()) {
-        return;
-    }
-    // Sized and placed against what is on screen rather than against the whole
-    // widget, so a clipped overview keeps the digits inside the strip instead
-    // of centring them on an edge.
-    const bool horizontal = m_orientation == Qt::Horizontal;
-    const qreal visibleLength = horizontal ? visible.width() : visible.height();
-    const qreal visibleBreadth = horizontal ? visible.height() : visible.width();
-
-    const QString text = TimeRemainingOverlay::remainingTimeToString(remainingSeconds);
-    const TimeRemainingOverlay::TextLayout layout = TimeRemainingOverlay::layoutFor(
-            text, visibleBreadth, visibleLength, m_timeRemainingScale);
-    if (!layout.valid) {
-        return;
-    }
-
-    float x, y;
-    TimeRemainingOverlay::alignedPosition(m_timeRemainingAlign,
-            static_cast<float>(visibleLength),
-            static_cast<float>(visibleBreadth),
-            static_cast<float>(layout.boxWidth()),
-            static_cast<float>(layout.boxHeight()),
-            &x,
-            &y);
-
-    PainterScope painterScope(pPainter);
-    if (m_orientation == Qt::Vertical) {
-        // length()/breadth() run along the overview, not the widget. This is
-        // the same rotation the mark labels use to follow it.
-        pPainter->translate(width(), 0);
-        pPainter->rotate(90.0);
-        // In that frame the axes run from the widget's top edge and its right
-        // edge, which is where the visible strip has to be measured from too.
-        x += static_cast<float>(visible.top());
-        y += static_cast<float>(width() - visible.right() - 1);
-    } else {
-        x += static_cast<float>(visible.left());
-        y += static_cast<float>(visible.top());
-    }
-    pPainter->translate(x, y);
-    // The whole overlay is drawn at this opacity so the summary stays visible
-    // through it.
-    pPainter->setOpacity(m_timeRemainingOpacity);
-
-    TimeRemainingOverlay::paintOverlay(pPainter,
-            layout,
-            text,
-            m_timeRemainingColor,
-            m_timeRemainingBackgroundColor);
 }
 
 void WOverview::drawPassthroughOverlay(QPainter* pPainter) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -22,12 +22,6 @@ class SkinContext;
 
 class WOverview : public WWidget, public TrackDropTarget {
     Q_OBJECT
-    /// Whether the time-remaining watermark is painted. The summary only stands
-    /// in for the scrolling waveform on the pages that don't carry one, so the
-    /// skin binds this to the tab it is on rather than to anything about the
-    /// deck. Defaults to on, so a skin that never binds it is unaffected.
-    Q_PROPERTY(bool timeRemainingVisible READ timeRemainingVisible WRITE
-                    setTimeRemainingVisible)
   public:
     WOverview(
             const QString& group,
@@ -38,10 +32,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     void setup(const QDomNode& node, const SkinContext& context);
     virtual void initWithTrack(TrackPointer pTrack);
 
-    bool timeRemainingVisible() const {
-        return m_bTimeRemainingVisible;
-    }
-    void setTimeRemainingVisible(bool visible);
 
     enum class Type {
         Filtered,
@@ -113,8 +103,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     void drawPickupPosition(QPainter* pPainter);
     void drawTimeRuler(QPainter* pPainter);
     void drawMarkLabels(QPainter* pPainter, const float offset, const float gain);
-    QRect visibleStripRect() const;
-    void drawTimeRemaining(QPainter* pPainter);
     void drawPassthroughOverlay(QPainter* pPainter);
     void paintText(const QString& text, QPainter* pPainter);
     double samplePositionToSeconds(double sample);
@@ -211,7 +199,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     PollingControlProxy m_trackSampleRateControl;
     PollingControlProxy m_trackSamplesControl;
     PollingControlProxy m_playpositionControl;
-    PollingControlProxy m_timeRemainingControl;
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
 
@@ -231,15 +218,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     QColor m_passthroughOverlayColor;
     QColor m_playedOverlayColor;
     QColor m_lowColor;
-    QColor m_timeRemainingColor;
-    QColor m_timeRemainingBackgroundColor;
-    double m_timeRemainingOpacity;
-    double m_timeRemainingScale;
-    Qt::Alignment m_timeRemainingAlign;
-    bool m_bTimeRemainingVisible;
-    /// Whole seconds left, so paints can be forced when the digits change
-    /// rather than only when the play marker crosses a pixel.
-    int m_iTimeRemainingSeconds;
     int m_dimBrightThreshold;
     parented_ptr<QLabel> m_pPassthroughLabel;
 


### PR DESCRIPTION
issue #9

## Summary

Adds tap-based switching between elapsed (`TIME`) and remaining (`REMAIN`) track time.

The selected Time Mode uses Mixxx's global `[Controls],ShowDurationRemaining` control, persists in the configuration, and applies to all decks.

## Changes

- Backport track-time click switching from upstream Mixxx.
- Limit BiteDJ to `TIME` and `REMAIN`, skipping the combined elapsed-and-remaining mode.
- Add `REMAIN / TIME` indicators to the Play page.
- Display track time at the right side of the deck header on non-Play pages.
- Remove the remaining-time watermark from the waveform overview.
- Add optional OpenType tabular-number support to `WLabel`.
- Use tabular digits for the deck time displays to prevent digits from shifting as the time changes.

## Behavior

Tapping a track-time display switches the global mode:

- `TIME`: elapsed time
- `REMAIN`: remaining time

The selected mode is shared by all decks and retained across restarts.

## Validation

- Verified the BiteDJ skin XML.
- Applied clang-format to the modified C++ files.
- Verified the changes with `git diff --check`.