### PR TITLE
feature: browser library sort column

### DIFF
--- a/src/library/librarycolumncontrol.h
+++ b/src/library/librarycolumncontrol.h
@@ -19,11 +19,9 @@ class WTrackTableViewHeader;
 // trigger is the [Library],column_visible_<name> + column_weight_<name>
 // ControlObjects set by the skin.
 //
-// The per-model header_state_pb (which the upstream menu writes) is unreachable
-// from the touch UI. This class wins over the protobuf for visibility and
-// width — column order and sort indicator still come from the protobuf
-// restore path in WTrackTableViewHeader, so those upstream behaviors are
-// preserved.
+// WTrackTableViewHeader saves/restores column order using the upstream
+// per-model header_state_pb. This class applies visibility and weighted
+// widths after that restore, overriding the protobuf's layout dimensions.
 //
 // Width semantics: each visible column has an integer weight (1..4). On
 // every apply pass the visible weights are summed and each column is sized

--- a/src/test/librarycolumncontrol_test.cpp
+++ b/src/test/librarycolumncontrol_test.cpp
@@ -1,6 +1,7 @@
 // Tests for the Bite DJ LibraryColumnControl-managed track table layout:
 // managed visibility/weights from mixxx.cfg, internal-column enforcement,
-// self-healing after model resets, and the rating column's minimum width.
+// self-healing after model resets, upstream-compatible order persistence,
+// and the rating column's minimum width.
 #include <gtest/gtest.h>
 
 #include <QApplication>
@@ -154,6 +155,8 @@ TEST_F(LibraryColumnControlTest, ManagedLayoutIsAppliedAndSelfHealing) {
             model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING);
     const int titleCol =
             model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+    const int artistCol =
+            model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST);
 
     // Managed layout per config: '#' (position), title, rating visible;
     // preview managed-invisible; internal track_id hidden.
@@ -186,4 +189,24 @@ TEST_F(LibraryColumnControlTest, ManagedLayoutIsAppliedAndSelfHealing) {
     EXPECT_TRUE(header->isSectionHidden(previewCol));
     EXPECT_FALSE(header->isSectionHidden(positionCol));
     EXPECT_GE(header->sectionSize(ratingCol), StarRating().sizeHint().width());
+
+    // Column order uses the upstream per-model header state, while a restored
+    // pixel width is replaced by BiteDJ's configured weight.
+    const int artistVisualIndex = header->visualIndex(artistCol);
+    header->moveSection(header->visualIndex(titleCol), artistVisualIndex);
+    header->resizeSection(titleCol, 37);
+
+    QTableView restoredView;
+    restoredView.resize(800, 480);
+    auto* restoredHeader =
+            new WTrackTableViewHeader(Qt::Horizontal, &restoredView);
+    restoredView.setModel(&model);
+    restoredView.setHorizontalHeader(restoredHeader);
+    restoredView.show();
+    QApplication::processEvents();
+
+    EXPECT_EQ(artistVisualIndex, restoredHeader->visualIndex(titleCol));
+    EXPECT_NE(37, restoredHeader->sectionSize(titleCol));
+    EXPECT_TRUE(restoredHeader->isSectionHidden(trackIdCol));
+    EXPECT_TRUE(restoredHeader->isSectionHidden(previewCol));
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -271,15 +271,11 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* pNewModel, bool restore
 
     setModel(pNewModel);
     setHorizontalHeader(header);
-    // Bite DJ fork: when LibraryColumnControl owns column visibility +
-    // widths, also lock the order and disable user drag-resize. Reorders
-    // wouldn't survive restart (we no longer save the per-model protobuf)
-    // and drag-resize would silently get clobbered by the next flex-weight
-    // re-apply on header resize — both are confusing transient UX. Fixed
-    // resize mode still permits programmatic resizeSection(), which is
-    // what LibraryColumnControl::applyTo uses.
+    // Use Qt's drag reordering and the upstream per-model header state.
+    // BiteDJ's weighted widths still own resizing; Fixed permits the
+    // programmatic resizeSection() calls made by LibraryColumnControl.
     const bool columnControlActive = LibraryColumnControl::tryInstance() != nullptr;
-    header->setSectionsMovable(!columnControlActive);
+    header->setSectionsMovable(true);
     if (columnControlActive) {
         header->setSectionResizeMode(QHeaderView::Fixed);
     }

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -2,6 +2,7 @@
 
 #include <QCheckBox>
 #include <QContextMenuEvent>
+#include <QScopedValueRollback>
 #include <QWidgetAction>
 
 #include "library/librarycolumncontrol.h"
@@ -82,7 +83,7 @@ QString HeaderViewState::saveState() const {
     if(m_view_state.SerializeToArray(array.data(), size)) {
         return QString(array.toBase64());
     } else {
-        qWarning() << "Could not serialze m_view_state to QByteArray of size "
+        qWarning() << "Could not serialize m_view_state to QByteArray of size "
                    << array.size();
         return "";
     }
@@ -135,9 +136,16 @@ void HeaderViewState::restoreState(WTrackTableViewHeader* pHeaders) {
 WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
         QWidget* pParent)
         : QHeaderView(orientation, pParent),
-          m_menu(tr("Show or hide columns."), this) {
+          m_menu(tr("Show or hide columns."), this),
+          m_restoringHeaderState(false) {
     if (auto* pColumnControl = LibraryColumnControl::tryInstance()) {
         pColumnControl->registerHeader(this);
+        // The appliance may be powered off without the normal widget
+        // destruction path, so persist a completed Qt header drag at once.
+        connect(this,
+                &QHeaderView::sectionMoved,
+                this,
+                &WTrackTableViewHeader::slotSaveColumnOrder);
         // Whenever Qt re-initializes this header's sections (model reset,
         // column count change — the moments hidden-section state can be
         // dropped), re-assert the managed layout. The appliance has no
@@ -311,16 +319,8 @@ void WTrackTableViewHeader::saveHeaderState() {
     if (!pTrackModel) {
         return;
     }
-    // Bite DJ fork: when LibraryColumnControl is active, skip the
-    // per-model protobuf entirely. Visibility and widths are owned by
-    // mixxx.cfg via [Library],ColumnVisible_*/ColumnWeight_*; writing the
-    // protobuf would just snapshot pixel widths from a transient
-    // header.width() and re-apply that stale layout on next launch before
-    // our control overrides it. Tradeoff: per-model sort indicator and
-    // column order are no longer persisted across launches.
-    if (LibraryColumnControl::tryInstance()) {
-        return;
-    }
+    // Keep the upstream format for column order. BiteDJ re-applies its
+    // managed visibility and weighted widths after restoring this state.
     // Convert the QByteArray to a Base64 string and save it.
     HeaderViewState view_state(*this);
     pTrackModel->setModelSetting("header_state_pb", view_state.saveState());
@@ -333,23 +333,7 @@ void WTrackTableViewHeader::restoreHeaderState() {
     if (!pTrackModel) {
         return;
     }
-
-    // Bite DJ fork: LibraryColumnControl is the sole source of truth for
-    // visibility and widths. Skip the per-model protobuf restore — see
-    // saveHeaderState above for the why. Pre-hide hidden-by-default
-    // columns we don't manage (e.g. composer, bitrate) so the table isn't
-    // cluttered on first show; managed hidden-by-default columns
-    // (TimesPlayed, Year) get their final visibility from applyTo below.
-    if (auto* pColumnControl = LibraryColumnControl::tryInstance()) {
-        loadDefaultHeaderState();
-        for (int i = 0; i < count(); ++i) {
-            if (pTrackModel->isColumnHiddenByDefault(i)) {
-                setSectionHidden(i, true);
-            }
-        }
-        pColumnControl->applyTo(this);
-        return;
-    }
+    const QScopedValueRollback restoringGuard(m_restoringHeaderState, true);
 
     const QString headerStateString = pTrackModel->getModelSetting("header_state_pb");
     if (headerStateString.isNull()) {
@@ -364,6 +348,15 @@ void WTrackTableViewHeader::restoreHeaderState() {
         } else {
             view_state.restoreState(this);
         }
+    }
+    // Restore order first, then let BiteDJ's config override the saved
+    // pixel widths and visibility. This does not move any sections.
+    slotReapplyColumnControl();
+}
+
+void WTrackTableViewHeader::slotSaveColumnOrder() {
+    if (!m_restoringHeaderState) {
+        saveHeaderState();
     }
 }
 
@@ -402,7 +395,7 @@ void WTrackTableViewHeader::slotReapplyColumnControl() {
     if (!pColumnControl || !pTrackModel) {
         return;
     }
-    // Mirrors the column-control branch of restoreHeaderState: pre-hide the
+    // After restoring the header state or repopulating the model, pre-hide the
     // hidden-by-default columns we don't manage, then let the control apply
     // visibility, internal-column hiding and flex widths.
     for (int i = 0; i < count(); ++i) {

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -74,6 +74,7 @@ class WTrackTableViewHeader : public QHeaderView {
 
   private slots:
     void showOrHideColumn(int);
+    void slotSaveColumnOrder();
     void slotReapplyColumnControl();
 
   private:
@@ -84,4 +85,5 @@ class WTrackTableViewHeader : public QHeaderView {
     QMenu m_menu;
     QMap<int, QCheckBox*> m_columnCheckBoxes;
     QMap<int, int> m_hiddenColumnSizes;
+    bool m_restoringHeaderState;
 };


### PR DESCRIPTION
# Summary

- Allow browser columns to be reordered by dragging
- Save the column order after dragging