### PR TITLE
fix(controller): improve CDJ-like browser navigation

### DIFF
--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -239,6 +239,30 @@ PioneerDDJ400.browseRotate = function(midichan, control, value, status) {
     }
 };
 
+// From Play, BROWSE press opens the browser. On the browser and other screens
+// it retains the mapping's existing focus-forward behavior.
+PioneerDDJ400.browsePress = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    if (engine.getValue("[Tab]", "current") === 0) {
+        engine.setValue("[Tab]", "current", 1);
+        engine.setValue("[Tab]", "library", 1);
+        return;
+    }
+    script.triggerControl("[Library]", "MoveFocusForward", 100);
+};
+
+// SHIFT + right LOAD toggles the Browser.
+PioneerDDJ400.toggleBrowser = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    const browserOpen = engine.getValue("[Tab]", "current") === 1;
+    engine.setValue("[Tab]", "current", browserOpen ? 0 : 1);
+    engine.setValue("[Tab]", browserOpen ? "overview" : "library", 1);
+};
+
 //
 // Channel level lights
 //

--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -26,13 +26,13 @@
                 </options>
             </control>
             <control>
-                <description>BROWSE - press - Move cursor between track list and tree view</description>
+                <description>BROWSE - press - Open Browse from Play, otherwise move focus forward</description>
                 <group>[Library]</group>
-                <key>MoveFocusForward</key> <!-- missing function to open Folder -->
+                <key>PioneerDDJ400.browsePress</key>
                 <status>0x96</status>
                 <midino>0x41</midino>
                 <options>
-                    <Normal/>
+                    <Script-Binding/>
                 </options>
             </control>
             <control>
@@ -65,6 +65,17 @@
                 <midino>0x47</midino>
                 <options>
                     <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOAD (DECK2) +SHIFT - press - Toggle Browser</description>
+                <group>[Library]</group>
+                <key>PioneerDDJ400.toggleBrowser</key>
+                <status>0x96</status>
+                <midino>0x7A</midino>
+                <options>
+                    <Script-Binding/>
                 </options>
             </control>
             <!-- BROWSER Section END -->

--- a/res/controllers/Pioneer-DDJ-FLX2-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX2-script.js
@@ -242,6 +242,30 @@ PioneerDDJFLX2.browseRotate = function(midichan, control, value, status) {
     }
 };
 
+// From Play, BROWSE press opens the browser. On the browser and other screens
+// it retains the mapping's existing focus-forward behavior.
+PioneerDDJFLX2.browsePress = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    if (engine.getValue("[Tab]", "current") === 0) {
+        engine.setValue("[Tab]", "current", 1);
+        engine.setValue("[Tab]", "library", 1);
+        return;
+    }
+    script.triggerControl("[Library]", "MoveFocusForward", 100);
+};
+
+// SHIFT + right LOAD toggles the Browser.
+PioneerDDJFLX2.toggleBrowser = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    const browserOpen = engine.getValue("[Tab]", "current") === 1;
+    engine.setValue("[Tab]", "current", browserOpen ? 0 : 1);
+    engine.setValue("[Tab]", browserOpen ? "overview" : "library", 1);
+};
+
 //
 // Channel level lights
 //

--- a/res/controllers/Pioneer-DDJ-FLX2.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX2.midi.xml
@@ -26,13 +26,13 @@
                 </options>
             </control>
             <control>
-                <description>BROWSE - press - Move cursor between track list and tree view</description>
+                <description>BROWSE - press - Open Browse from Play, otherwise move focus forward</description>
                 <group>[Library]</group>
-                <key>MoveFocusForward</key> <!-- missing function to open Folder -->
+                <key>PioneerDDJFLX2.browsePress</key>
                 <status>0x96</status>
                 <midino>0x41</midino>
                 <options>
-                    <Normal/>
+                    <Script-Binding/>
                 </options>
             </control>
             <control>
@@ -65,6 +65,17 @@
                 <midino>0x47</midino>
                 <options>
                     <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOAD (DECK2) +SHIFT - press - Toggle Browser</description>
+                <group>[Library]</group>
+                <key>PioneerDDJFLX2.toggleBrowser</key>
+                <status>0x96</status>
+                <midino>0x7A</midino>
+                <options>
+                    <Script-Binding/>
                 </options>
             </control>
             <!-- BROWSER Section END -->

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -313,6 +313,30 @@ PioneerDDJFLX4.browseRotate = function(midichan, control, value, status) {
     }
 };
 
+// From Play, BROWSE press opens the browser. On the browser and other screens
+// it retains the mapping's existing focus-forward behavior.
+PioneerDDJFLX4.browsePress = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    if (engine.getValue("[Tab]", "current") === 0) {
+        engine.setValue("[Tab]", "current", 1);
+        engine.setValue("[Tab]", "library", 1);
+        return;
+    }
+    script.triggerControl("[Library]", "MoveFocusForward", 100);
+};
+
+// SHIFT + right LOAD toggles the Browser.
+PioneerDDJFLX4.toggleBrowser = function(_midichan, _control, value) {
+    if (value === 0) {
+        return;
+    }
+    const browserOpen = engine.getValue("[Tab]", "current") === 1;
+    engine.setValue("[Tab]", "current", browserOpen ? 0 : 1);
+    engine.setValue("[Tab]", browserOpen ? "overview" : "library", 1);
+};
+
 //
 // Channel level lights
 //

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -36,13 +36,13 @@
                 </options>
             </control>
             <control>
-                <description>BROWSE - press - Move cursor between track list and tree view</description>
+                <description>BROWSE - press - Open Browse from Play, otherwise move focus forward</description>
                 <group>[Library]</group>
-                <key>MoveFocusForward</key> <!-- missing function to open Folder -->
+                <key>PioneerDDJFLX4.browsePress</key>
                 <status>0x96</status>
                 <midino>0x41</midino>
                 <options>
-                    <Normal/>
+                    <Script-Binding/>
                 </options>
             </control>
             <control>
@@ -75,6 +75,17 @@
                 <midino>0x47</midino>
                 <options>
                     <Normal/>
+                </options>
+            </control>
+
+            <control>
+                <description>LOAD (DECK2) +SHIFT - press - Toggle Browser</description>
+                <group>[Library]</group>
+                <key>PioneerDDJFLX4.toggleBrowser</key>
+                <status>0x96</status>
+                <midino>0x7A</midino>
+                <options>
+                    <Script-Binding/>
                 </options>
             </control>
             <!-- BROWSER Section END -->

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -34,6 +34,19 @@ bool bitedj_isLibraryPageActive() {
             ControlFlag::NoWarnIfMissing);
     return !pCo || pCo->get() > 0.0;
 }
+
+void bitedj_showPlayPage() {
+    ControlObject* pLibraryTab = ControlObject::getControl(
+            ConfigKey(QStringLiteral("[Tab]"), QStringLiteral("library")),
+            ControlFlag::NoWarnIfMissing);
+    if (!pLibraryTab) {
+        return;
+    }
+    ControlObject::set(
+            ConfigKey(QStringLiteral("[Tab]"), QStringLiteral("current")), 0.0);
+    ControlObject::set(
+            ConfigKey(QStringLiteral("[Tab]"), QStringLiteral("overview")), 1.0);
+}
 } // namespace
 
 LoadToGroupController::LoadToGroupController(LibraryControl* pParent, const QString& group)
@@ -604,8 +617,26 @@ void LibraryControl::slotLoadSelectedTrackToGroup(const QString& group, bool pla
     }
 
     WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
-    if (pTrackTableView) {
-        pTrackTableView->loadSelectedTrackToGroup(group, play);
+    if (!pTrackTableView) {
+        return;
+    }
+
+    // Return to the Play page only after a track load has been accepted. Since
+    // loadSelectedTrackToGroup() returns void, observe loadTrackToPlayer, which
+    // is emitted only after the table's load guards have passed. A successful
+    // emission returns to Play; otherwise the Browser remains open.
+    bool loadRequested = false;
+    const auto loadConnection = connect(
+            pTrackTableView,
+            &WTrackTableView::loadTrackToPlayer,
+            this,
+            [&loadRequested] { loadRequested = true; },
+            Qt::DirectConnection);
+    pTrackTableView->loadSelectedTrackToGroup(group, play);
+    disconnect(loadConnection);
+
+    if (loadRequested) {
+        bitedj_showPlayPage();
     }
 }
 
@@ -795,20 +826,22 @@ void LibraryControl::slotMoveFocusBackward(double v) {
 }
 
 void LibraryControl::slotMoveFocus(double v) {
-    // Backward focus and other contexts (dialogs, search box) keep stock
-    // Tab/BackTab semantics.
-    if (v > 0) {
-        if (m_focusedWidget == FocusWidget::Sidebar) {
+    if (m_focusedWidget == FocusWidget::Sidebar) {
+        if (v > 0) {
             slotGoToItem(1);
             return;
         }
-        if (m_focusedWidget == FocusWidget::TracksTable) {
+    } else if (m_focusedWidget == FocusWidget::TracksTable) {
+        if (v < 0) {
             ControlObject::set(ConfigKey(QStringLiteral("[Sidebar]"),
                                        QStringLiteral("sidebar_visible")),
                     1);
-            return;
         }
+        // A track is activated with LOAD, not by pressing the browse encoder.
+        return;
     }
+
+    // Other contexts (dialogs, search box) keep stock Tab/BackTab semantics.
     // Don't use Key_Tab + ShiftModifier for moving focus backwards!
     // This would indeed move the focus, though it has a significant side-effect
     // compared to pressing Shift + Tab on a real keyboard:


### PR DESCRIPTION
Improve browser navigation for DDJ-400, DDJ-FLX4, and DDJ-FLX2.

- Shift+Browse encoder push: move back from the track list to the sidebar
- Browse encoder push: open the Browser from the Play screen
- LOAD: return to the Play screen after successfully loading a track
- Shift+Right LOAD: toggle between the Play and Browser screens