### PR TITLE
fix(waveform): use skin-defined hot cue labels in overview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/metronomeclick.cpp
   src/effects/backends/builtin/moogladder4filtereffect.cpp
   src/effects/backends/builtin/compressoreffect.cpp
+  src/effects/backends/builtin/cfxfiltereffect.cpp
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp

--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -27,14 +27,13 @@
 //                SHIFT + LEVEL/DEPTH controls the Meta knob of the focused Effect
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
 //      * Loop Section:
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -552,13 +551,33 @@ PioneerDDJ400.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJ400.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJ400.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJ400.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJ400.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -547,7 +547,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJ400.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -557,9 +557,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJ400.quickJumpBack</key>
+                <key>PioneerDDJ400.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -568,7 +568,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJ400.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -578,9 +578,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJ400.quickJumpBack</key>
+                <key>PioneerDDJ400.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -589,7 +589,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJ400.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -599,9 +599,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJ400.quickJumpForward</key>
+                <key>PioneerDDJ400.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -610,7 +610,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJ400.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -620,9 +620,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJ400.quickJumpForward</key>
+                <key>PioneerDDJ400.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/controllers/Pioneer-DDJ-FLX2-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX2-script.js
@@ -29,14 +29,13 @@
 //                SHIFT + LEVEL/DEPTH controls the Meta knob of the focused Effect
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
 //      * Loop Section:
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -553,13 +552,33 @@ PioneerDDJFLX2.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJFLX2.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJFLX2.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJFLX2.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJFLX2.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-FLX2.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX2.midi.xml
@@ -547,7 +547,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX2.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -557,9 +557,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX2.quickJumpBack</key>
+                <key>PioneerDDJFLX2.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -568,7 +568,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX2.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -578,9 +578,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX2.quickJumpBack</key>
+                <key>PioneerDDJFLX2.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -589,7 +589,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX2.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -599,9 +599,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX2.quickJumpForward</key>
+                <key>PioneerDDJFLX2.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -610,7 +610,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX2.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -620,9 +620,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX2.quickJumpForward</key>
+                <key>PioneerDDJFLX2.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -25,7 +25,7 @@
 //                ON/OFF toggles focused effect slot
 //                SHIFT + ON/OFF disables all three effect slots.
 //
-//      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
+//      * Memory Cue CALL, MEMORY and DELETE (CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
 //
 //  Not implemented (after discussion and trial attempts):
@@ -33,7 +33,6 @@
 //        * -4BEAT auto loop (hacky---prefer a clean way to set a 4 beat loop
 //                            from a previous position on long press)
 //
-//        * CUE/LOOP CALL - memory & delete (complex and not useful. Hot cues are sufficient)
 //
 //      * Secondary pad modes (trial attempts complex and too experimental)
 //        * Keyboard mode
@@ -646,13 +645,33 @@ PioneerDDJFLX4.stopLoopInPendingBlink = function(status, group) {
 
 PioneerDDJFLX4.cueLoopCallLeft = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 0.5);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 0.5);
+        } else {
+            engine.setValue(group, "memorycue_prev", 1);
+        }
     }
 };
 
 PioneerDDJFLX4.cueLoopCallRight = function(_channel, _control, value, _status, group) {
     if (value) {
-        engine.setValue(group, "loop_scale", 2.0);
+        if (engine.getValue(group, "loop_enabled") > 0) {
+            engine.setValue(group, "loop_scale", 2.0);
+        } else {
+            engine.setValue(group, "memorycue_next", 1);
+        }
+    }
+};
+
+PioneerDDJFLX4.memoryCueSet = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_set", 1);
+    }
+};
+
+PioneerDDJFLX4.memoryCueDelete = function(_channel, _control, value, _status, group) {
+    if (value) {
+        engine.setValue(group, "memorycue_delete", 1);
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -557,7 +557,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK1) - previous memory cue / half active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX4.cueLoopCallLeft</key>
                 <status>0x90</status>
@@ -567,9 +567,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK1) - delete memory cue at current position</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <key>PioneerDDJFLX4.memoryCueDelete</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
@@ -578,7 +578,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - half active loop</description>
+                <description>CUE/LOOP CALL LEFT (DECK2) - previous memory cue / half active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX4.cueLoopCallLeft</key>
                 <status>0x91</status>
@@ -588,9 +588,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - press - quick jump back</description>
+                <description>CUE/LOOP CALL LEFT + SHIFT (DECK2) - delete memory cue at current position</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.quickJumpBack</key>
+                <key>PioneerDDJFLX4.memoryCueDelete</key>
                 <status>0x91</status>
                 <midino>0x3E</midino>
                 <options>
@@ -599,7 +599,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK1) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK1) - next memory cue / double active loop</description>
                 <group>[Channel1]</group>
                 <key>PioneerDDJFLX4.cueLoopCallRight</key>
                 <status>0x90</status>
@@ -609,9 +609,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK1) - store memory cue</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <key>PioneerDDJFLX4.memoryCueSet</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
@@ -620,7 +620,7 @@
             </control>
 
             <control>
-                <description>CUE/LOOP CALL LEFT (DECK2) - press - double active loop</description>
+                <description>CUE/LOOP CALL RIGHT (DECK2) - next memory cue / double active loop</description>
                 <group>[Channel2]</group>
                 <key>PioneerDDJFLX4.cueLoopCallRight</key>
                 <status>0x91</status>
@@ -630,9 +630,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - press - quick jump forwards</description>
+                <description>CUE/LOOP CALL RIGHT + SHIFT (DECK2) - store memory cue</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.quickJumpForward</key>
+                <key>PioneerDDJFLX4.memoryCueSet</key>
                 <status>0x91</status>
                 <midino>0x3D</midino>
                 <options>

--- a/res/effects/chains/CFX Filter.xml
+++ b/res/effects/chains/CFX Filter.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<EffectChain>
+ <Name>CFX Filter</Name>
+ <MixMode>DRY/WET</MixMode>
+ <SuperParameterValue>0.5</SuperParameterValue>
+ <Effects>
+  <Effect>
+   <MetaParameterValue>0.5</MetaParameterValue>
+   <Id>us.bitedj.effects.cfxfilter</Id>
+   <BackendType>Built-In</BackendType>
+   <Parameters>
+    <Parameter>
+     <Id>lpf</Id>
+     <Value>1</Value>
+     <LinkType>LINKED_LEFT</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+    <Parameter>
+     <Id>q</Id>
+     <Value>2</Value>
+     <LinkType>NONE</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+    <Parameter>
+     <Id>hpf</Id>
+     <Value>0</Value>
+     <LinkType>LINKED_RIGHT</LinkType>
+     <LinkInversion>0</LinkInversion>
+     <Hidden>0</Hidden>
+    </Parameter>
+   </Parameters>
+  </Effect>
+  <Effect/>
+  <Effect/>
+  <Effect/>
+ </Effects>
+</EffectChain>

--- a/res/skins/BiteDJ/deck.xml
+++ b/res/skins/BiteDJ/deck.xml
@@ -528,7 +528,7 @@
               <TextColor>#c7b205</TextColor>
               <Align>top</Align>
             </Mark>
-            <!-- Memory cue bank (slots 17-24, chronological). Bottom-aligned
+            <!-- Memory cue bank (slots 17-26, chronological). Bottom-aligned
                  so a glance separates them from the hot cues on top; they sit
                  alongside CUE, which is memory cue 1. Keep in step with
                  kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
@@ -584,6 +584,20 @@
             <Mark>
               <Hotcue>24</Hotcue>
               <Text>M8</Text>
+              <Color>#9aa0a6</Color>
+              <TextColor>#9aa0a6</TextColor>
+              <Align>bottom</Align>
+            </Mark>
+            <Mark>
+              <Hotcue>25</Hotcue>
+              <Text>M9</Text>
+              <Color>#9aa0a6</Color>
+              <TextColor>#9aa0a6</TextColor>
+              <Align>bottom</Align>
+            </Mark>
+            <Mark>
+              <Hotcue>26</Hotcue>
+              <Text>M10</Text>
               <Color>#9aa0a6</Color>
               <TextColor>#9aa0a6</TextColor>
               <Align>bottom</Align>

--- a/res/skins/BiteDJ/deck.xml
+++ b/res/skins/BiteDJ/deck.xml
@@ -133,6 +133,26 @@
                 <Elide>right</Elide>
                 <Channel><Variable name="channel"/></Channel>
               </TrackProperty>
+              <WidgetGroup>
+                <ObjectName>DeckHeaderTime</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>100max,20f</Size>
+                <Children>
+                  <NumberPos>
+                    <ObjectName>DeckHeaderTimeValue</ObjectName>
+                    <Size>100max,20f</Size>
+                    <TooltipId>track_time</TooltipId>
+                    <NumberOfDigits>6</NumberOfDigits>
+                    <TabularNumbers>true</TabularNumbers>
+                    <Channel><Variable name="channel"/></Channel>
+                  </NumberPos>
+                </Children>
+                <Connection>
+                  <ConfigKey>[Tab],overview</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                  <Transform><Not/></Transform>
+                </Connection>
+              </WidgetGroup>
             </Children>
           </WidgetGroup>
         </Children>
@@ -236,11 +256,44 @@
             <Layout>vertical</Layout>
             <Size>0me,0me</Size>
             <Children>
-              <Label>
+              <WidgetGroup>
                 <ObjectName>DeckTrackTimeTitle</ObjectName>
-                <Text>Time</Text>
                 <Size>200me,25f</Size>
-              </Label>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <Label>
+                    <ObjectName>DeckTrackTimeRemainLabel</ObjectName>
+                    <Text>REMAIN</Text>
+                    <Connection>
+                      <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
+                      <Transform>
+                        <IsEqual>0</IsEqual>
+                        <Not/>
+                      </Transform>
+                      <BindProperty>highlight</BindProperty>
+                    </Connection>
+                  </Label>
+                  <Label>
+                    <ObjectName>DeckTrackTimeSlashLabel</ObjectName>
+                    <Text>/</Text>
+                  </Label>
+                  <Label>
+                    <ObjectName>DeckTrackTimeTimeLabel</ObjectName>
+                    <Text>TIME</Text>
+                    <Connection>
+                      <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
+                      <Transform>
+                        <IsEqual>1</IsEqual>
+                        <Not/>
+                      </Transform>
+                      <BindProperty>highlight</BindProperty>
+                    </Connection>
+                  </Label>
+                  <Label>
+                    <Size>0me,0me</Size>
+                  </Label>
+                </Children>
+              </WidgetGroup>
               <WidgetGroup>
                 <ObjectName>DeckTrackTimeWrapper</ObjectName>
                 <Layout>horizontal</Layout>
@@ -260,11 +313,13 @@
                             <ObjectName>DeckTrackTimeMini</ObjectName>
                             <MaximumSize>150,-1</MaximumSize>
                             <Text>0:00.00</Text>
+                            <TabularNumbers>true</TabularNumbers>
                           </Label>
                           <Label>
                             <ObjectName>DeckTrackTime</ObjectName>
                             <MinimumSize>150,-1</MinimumSize>
                             <Text>0:00.00</Text>
+                            <TabularNumbers>true</TabularNumbers>
                           </Label>
                         </Children>
                       </SizeAwareStack>
@@ -286,6 +341,7 @@
                             <MaximumSize>150,-1</MaximumSize>
                             <TooltipId>track_time</TooltipId>
                             <NumberOfDigits>6</NumberOfDigits>
+                            <TabularNumbers>true</TabularNumbers>
                             <Channel><Variable name="channel"/></Channel>
                             <Connection>
                               <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
@@ -300,6 +356,7 @@
                             <MinimumSize>150,-1</MinimumSize>
                             <TooltipId>track_time</TooltipId>
                             <NumberOfDigits>6</NumberOfDigits>
+                            <TabularNumbers>true</TabularNumbers>
                             <Channel><Variable name="channel"/></Channel>
                             <Connection>
                               <ConfigKey>[Controls],ShowDurationRemaining</ConfigKey>
@@ -325,7 +382,7 @@
             <ObjectName>TrackBPMRangeContainer</ObjectName>
             <Layout>vertical</Layout>
             <Size>65max,40max</Size>
-            <Children>              
+            <Children>
               <WidgetGroup>
                 <ObjectName>DeckBPMRangePercent</ObjectName>
                 <Size>30me,16f</Size>
@@ -446,22 +503,6 @@
             <SignalMidColor>#007de1</SignalMidColor>
             <SignalHighColor>#007de1</SignalHighColor>
             <PlayedOverlayColor>#40ffffff</PlayedOverlayColor>
-            <!-- Time left in the track, drawn straight onto the summary as a
-                 watermark: centred and translucent enough to read the signal
-                 through. Scale is a share of the height the summary is
-                 *visible* over, which here is the container's 50px and not the
-                 widget's own 100px above — the strip deliberately shows the top
-                 half of a double-height overview, so a scale against the widget
-                 would centre the digits on the cut edge and lose their bottom
-                 half. This strip is what the settings/browse/sampler pages show
-                 of a deck, so it is the one place the countdown has to be
-                 readable from — on the Play page the scrolling waveform and the
-                 big Time readout are both on screen, so the watermark is off
-                 there (bound below). -->
-            <TimeRemainingAlign>center</TimeRemainingAlign>
-            <TimeRemainingColor>#fff</TimeRemainingColor>
-            <TimeRemainingOpacity>0.55</TimeRemainingOpacity>
-            <TimeRemainingScale>0.57</TimeRemainingScale>
             <Mark>
               <Control>cue_point</Control>
               <Color>#eb870f</Color>
@@ -621,15 +662,6 @@
             </MarkRange>
             <Connection>
               <ConfigKey>[Channel<Variable name="channel"/>],playposition</ConfigKey>
-            </Connection>
-            <!-- The watermark is off on the Play page, where the scrolling
-                 waveform and the Time readout already carry the countdown.
-                 Kept next to the connection above because setupConnections
-                 walks siblings from the first <Connection> on. -->
-            <Connection>
-              <ConfigKey>[Tab],overview</ConfigKey>
-              <BindProperty>timeRemainingVisible</BindProperty>
-              <Transform><Not/></Transform>
             </Connection>
           </Overview>
         </Children>

--- a/res/skins/BiteDJ/style.qss
+++ b/res/skins/BiteDJ/style.qss
@@ -161,10 +161,36 @@ WPushButton[value="1"]:hover {
   background-color: rgba(241, 89, 33, 0.12);
 }
 
-#DeckChannelTitle, #DeckTrackTimeTitle, #DeckTempoTitle {
+#DeckChannelTitle, #DeckTempoTitle,
+#DeckTrackTimeRemainLabel, #DeckTrackTimeSlashLabel, #DeckTrackTimeTimeLabel {
   font-size: 14px;
   font-weight: bold;
   text-transform: uppercase;
+}
+
+#DeckTrackTimeRemainLabel, #DeckTrackTimeTimeLabel {
+  color: #4a4a4a;
+}
+
+#DeckTrackTimeRemainLabel[highlight="1"],
+#DeckTrackTimeTimeLabel[highlight="1"] {
+  color: #e5e6ea;
+}
+
+#DeckTrackTimeSlashLabel {
+  color: #98989a;
+  padding: 0 1px;
+}
+
+#DeckHeaderTime {
+  qproperty-layoutAlignment: 'AlignRight | AlignVCenter';
+}
+
+#DeckHeaderTimeValue {
+  font-size: 18px;
+  font-weight: bold;
+  qproperty-alignment: 'AlignRight | AlignVCenter';
+  padding-right: 1px;
 }
 
 #DeckPlayingLeft, #DeckPlayingRight {

--- a/res/skins/BiteDJ/templates/cue_deck_page.xml
+++ b/res/skins/BiteDJ/templates/cue_deck_page.xml
@@ -143,7 +143,7 @@
         </Connection>
       </WidgetGroup>
 
-      <!-- Memory cue bank: slots 17-24, chronological. Keep in step with
+      <!-- Memory cue bank: slots 17-26, chronological. Keep in step with
            kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
       <WidgetGroup>
         <ObjectName>CuePanel_Grid</ObjectName>
@@ -175,6 +175,11 @@
                 <SetVariable name="hotcue">20</SetVariable>
                 <SetVariable name="label">M4</SetVariable>
               </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">21</SetVariable>
+                <SetVariable name="label">M5</SetVariable>
+              </Template>
             </Children>
           </WidgetGroup>
           <WidgetGroup>
@@ -182,11 +187,6 @@
             <Layout>horizontal</Layout>
             <Size>0me,56f</Size>
             <Children>
-              <Template src="skin:templates/cue_pad.xml">
-                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
-                <SetVariable name="hotcue">21</SetVariable>
-                <SetVariable name="label">M5</SetVariable>
-              </Template>
               <Template src="skin:templates/cue_pad.xml">
                 <SetVariable name="channel"><Variable name="channel"/></SetVariable>
                 <SetVariable name="hotcue">22</SetVariable>
@@ -201,6 +201,16 @@
                 <SetVariable name="channel"><Variable name="channel"/></SetVariable>
                 <SetVariable name="hotcue">24</SetVariable>
                 <SetVariable name="label">M8</SetVariable>
+              </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">25</SetVariable>
+                <SetVariable name="label">M9</SetVariable>
+              </Template>
+              <Template src="skin:templates/cue_pad.xml">
+                <SetVariable name="channel"><Variable name="channel"/></SetVariable>
+                <SetVariable name="hotcue">26</SetVariable>
+                <SetVariable name="label">M10</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>

--- a/res/skins/BiteDJ/templates/cue_pad.xml
+++ b/res/skins/BiteDJ/templates/cue_pad.xml
@@ -19,7 +19,7 @@
   Variables:
     channel: deck number.
     hotcue:  hotcue slot, 1-based.
-    label:   what the pad is called (A-H, M1-M8).
+    label:   what the pad is called (A-H, M1-M10).
 -->
 <Template>
   <HotcueButton>

--- a/res/skins/BiteDJ/waveform.xml
+++ b/res/skins/BiteDJ/waveform.xml
@@ -194,7 +194,7 @@
           <Align>top</Align>
         </Mark>
 
-        <!-- Memory cue bank (slots 17-24, chronological). Bottom-aligned to
+        <!-- Memory cue bank (slots 17-26, chronological). Bottom-aligned to
              separate them at a glance from the hot cues on top. Keep in step
              with kMemoryCueBankStart / kMemoryCueBankSize in cueinfo.h. -->
         <Mark>
@@ -249,6 +249,20 @@
         <Mark>
           <Hotcue>24</Hotcue>
           <Text>M8</Text>
+          <Color>#9aa0a6</Color>
+          <TextColor>#9aa0a6</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Hotcue>25</Hotcue>
+          <Text>M9</Text>
+          <Color>#9aa0a6</Color>
+          <TextColor>#9aa0a6</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Hotcue>26</Hotcue>
+          <Text>M10</Text>
           <Color>#9aa0a6</Color>
           <TextColor>#9aa0a6</TextColor>
           <Align>bottom</Align>

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -17,6 +17,7 @@
 #include "effects/backends/builtin/reverbeffect.h"
 #endif
 #include "effects/backends/builtin/autopaneffect.h"
+#include "effects/backends/builtin/cfxfiltereffect.h"
 #include "effects/backends/builtin/compressoreffect.h"
 #include "effects/backends/builtin/distortioneffect.h"
 #include "effects/backends/builtin/echoeffect.h"
@@ -44,6 +45,7 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<LoudnessContourEffect>();
     // Fading Effects
     registerEffect<FilterEffect>();
+    registerEffect<CFXFilterEffect>();
     registerEffect<MoogLadder4FilterEffect>();
     registerEffect<BitCrusherEffect>();
     registerEffect<WhiteNoiseEffect>();

--- a/src/effects/backends/builtin/cfxfiltereffect.cpp
+++ b/src/effects/backends/builtin/cfxfiltereffect.cpp
@@ -1,0 +1,178 @@
+#include "effects/backends/builtin/cfxfiltereffect.h"
+
+#include <cmath>
+
+#include "effects/backends/effectmanifest.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/math.h"
+
+namespace {
+constexpr double kBypassLowCorner = 22050.0;
+constexpr double kBypassHighCorner = 13.0;
+constexpr double kDefaultQ = 2.0;
+constexpr double kLowPassMinimum = 100.0;
+constexpr double kLowPassMaximum = 12000.0;
+constexpr double kLowPassCurveExponent = 2.75;
+constexpr double kLowPassBypassPosition = 59.0 / 64.0;
+constexpr double kHighPassMaximum = 7000.0;
+constexpr double kHighPassCurveExponent = 3.0;
+
+// A single Q=2 biquad with these curves fits two measured CFX Filter
+// passes with median response errors of 1.28 dB (LPF) and 1.18 dB (HPF).
+double lowPassCutoff(double position) {
+    position = math_clamp(position, 0.0, 1.0);
+    if (position >= kLowPassBypassPosition) {
+        return kBypassLowCorner;
+    }
+    const double shapedPosition = std::pow(position, kLowPassCurveExponent);
+    return math_min(kLowPassMinimum +
+                    (kBypassLowCorner - kLowPassMinimum) * shapedPosition,
+            kLowPassMaximum);
+}
+
+double highPassCutoff(double position) {
+    position = math_clamp(position, 0.0, 1.0);
+    const double shapedPosition = std::pow(position, kHighPassCurveExponent);
+    return kBypassHighCorner +
+            (kHighPassMaximum - kBypassHighCorner) * shapedPosition;
+}
+} // namespace
+
+QString CFXFilterEffect::getId() {
+    return QStringLiteral("us.bitedj.effects.cfxfilter");
+}
+
+EffectManifestPointer CFXFilterEffect::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("CFX Filter"));
+    pManifest->setShortName(QObject::tr("CFX Filter"));
+    pManifest->setAuthor("The BiteDJ Team");
+    pManifest->setVersion("1.0");
+    pManifest->setDescription(
+            QObject::tr("A resonant high-pass/low-pass filter modeled from rekordbox "
+                        "CFX measurements."));
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setMetaknobDefault(0.5);
+
+    EffectManifestParameterPointer lpf = pManifest->addParameter();
+    lpf->setId("lpf");
+    lpf->setName(QObject::tr("Low Pass Filter Position"));
+    lpf->setShortName(QObject::tr("LPF"));
+    lpf->setDescription(QObject::tr("Measured low-pass filter knob position"));
+    lpf->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    lpf->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    lpf->setDefaultLinkType(EffectManifestParameter::LinkType::LinkedLeft);
+    lpf->setNeutralPointOnScale(1.0);
+    lpf->setRange(0.0, 1.0, 1.0);
+
+    EffectManifestParameterPointer q = pManifest->addParameter();
+    q->setId("q");
+    q->setName(QObject::tr("Resonance"));
+    q->setShortName(QObject::tr("Q"));
+    q->setDescription(QObject::tr("Resonance at the filter cutoff"));
+    q->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    q->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    q->setRange(0.707106781, kDefaultQ, 3.0);
+
+    EffectManifestParameterPointer hpf = pManifest->addParameter();
+    hpf->setId("hpf");
+    hpf->setName(QObject::tr("High Pass Filter Position"));
+    hpf->setShortName(QObject::tr("HPF"));
+    hpf->setDescription(QObject::tr("Measured high-pass filter knob position"));
+    hpf->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    hpf->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    hpf->setDefaultLinkType(EffectManifestParameter::LinkType::LinkedRight);
+    hpf->setNeutralPointOnScale(0.0);
+    hpf->setRange(0.0, 0.0, 1.0);
+
+    return pManifest;
+}
+
+CFXFilterGroupState::CFXFilterGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_buffer(engineParameters.samplesPerBuffer()),
+          m_pLowFilter(new EngineFilterBiquad1Low(
+                  engineParameters.sampleRate(), kBypassLowCorner, kDefaultQ, true)),
+          m_pHighFilter(new EngineFilterBiquad1High(
+                  engineParameters.sampleRate(), kBypassHighCorner, kDefaultQ, true)),
+          m_loFreq(kBypassLowCorner),
+          m_q(kDefaultQ),
+          m_hiFreq(kBypassHighCorner) {
+}
+
+CFXFilterGroupState::~CFXFilterGroupState() noexcept {
+    delete m_pLowFilter;
+    delete m_pHighFilter;
+}
+
+void CFXFilterEffect::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pLPF = parameters.value("lpf");
+    m_pQ = parameters.value("q");
+    m_pHPF = parameters.value("hpf");
+}
+
+void CFXFilterEffect::processChannel(
+        CFXFilterGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(groupFeatures);
+
+    const double lpfPosition =
+            enableState == EffectEnableState::Disabling ? 1.0 : m_pLPF->value();
+    const double hpfPosition =
+            enableState == EffectEnableState::Disabling ? 0.0 : m_pHPF->value();
+    const double q = m_pQ->value();
+    const double lpf = lowPassCutoff(lpfPosition);
+    const double hpf = highPassCutoff(hpfPosition);
+
+    if (pState->m_loFreq != lpf || pState->m_q != q) {
+        pState->m_pLowFilter->setFrequencyCorners(engineParameters.sampleRate(),
+                lpf,
+                q);
+    }
+    if (pState->m_hiFreq != hpf || pState->m_q != q) {
+        pState->m_pHighFilter->setFrequencyCorners(engineParameters.sampleRate(),
+                hpf,
+                q);
+    }
+
+    const bool lpfEnabled = lpfPosition < kLowPassBypassPosition;
+    const bool hpfEnabled = hpfPosition > 0.0;
+    const CSAMPLE* pLpfInput = pState->m_buffer.data();
+    CSAMPLE* pHpfOutput = pState->m_buffer.data();
+    if (!lpfEnabled && pState->m_loFreq >= kBypassLowCorner) {
+        pHpfOutput = pOutput;
+        pLpfInput = pHpfOutput;
+    }
+
+    if (hpfEnabled) {
+        pState->m_pHighFilter->process(
+                pInput, pHpfOutput, engineParameters.samplesPerBuffer());
+    } else if (pState->m_hiFreq > kBypassHighCorner) {
+        pState->m_pHighFilter->processAndPauseFilter(
+                pInput, pHpfOutput, engineParameters.samplesPerBuffer());
+    } else {
+        pLpfInput = pInput;
+    }
+
+    if (lpfEnabled) {
+        pState->m_pLowFilter->process(
+                pLpfInput, pOutput, engineParameters.samplesPerBuffer());
+    } else if (pState->m_loFreq < kBypassLowCorner) {
+        pState->m_pLowFilter->processAndPauseFilter(
+                pLpfInput, pOutput, engineParameters.samplesPerBuffer());
+    } else if (pLpfInput == pInput && pOutput != pInput) {
+        SampleUtil::copy(pOutput, pInput, engineParameters.samplesPerBuffer());
+    }
+
+    pState->m_loFreq = lpf;
+    pState->m_q = q;
+    pState->m_hiFreq = hpf;
+}

--- a/src/effects/backends/builtin/cfxfiltereffect.h
+++ b/src/effects/backends/builtin/cfxfiltereffect.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "effects/backends/effectprocessor.h"
+#include "util/class.h"
+#include "util/samplebuffer.h"
+#include "util/types.h"
+
+class EngineFilterBiquad1Low;
+class EngineFilterBiquad1High;
+
+struct CFXFilterGroupState : public EffectState {
+    explicit CFXFilterGroupState(const mixxx::EngineParameters& engineParameters);
+    ~CFXFilterGroupState() noexcept override;
+
+    mixxx::SampleBuffer m_buffer;
+    EngineFilterBiquad1Low* m_pLowFilter;
+    EngineFilterBiquad1High* m_pHighFilter;
+
+    double m_loFreq;
+    double m_q;
+    double m_hiFreq;
+};
+
+class CFXFilterEffect : public EffectProcessorImpl<CFXFilterGroupState> {
+  public:
+    CFXFilterEffect() = default;
+    ~CFXFilterEffect() override = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            CFXFilterGroupState* pState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            EffectEnableState enableState,
+            const GroupFeatureState& groupFeatures) override;
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pLPF;
+    EngineEffectParameterPointer m_pQ;
+    EngineEffectParameterPointer m_pHPF;
+
+    DISALLOW_COPY_AND_ASSIGN(CFXFilterEffect);
+};

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -6,7 +6,7 @@
 #include <QMessageBox>
 
 #include "effects/backends/builtin/biquadfullkilleqeffect.h"
-#include "effects/backends/builtin/filtereffect.h"
+#include "effects/backends/builtin/cfxfiltereffect.h"
 #include "effects/backends/effectmanifest.h"
 #include "effects/effectchain.h"
 #include "effects/presets/effectchainpreset.h"
@@ -693,7 +693,7 @@ EffectManifestPointer EffectChainPresetManager::getDefaultEqEffect() {
 
 EffectChainPresetPointer EffectChainPresetManager::getDefaultQuickEffectPreset() {
     EffectManifestPointer pDefaultQuickEffectManifest = m_pBackendManager->getManifest(
-            FilterEffect::getId(), EffectBackendType::BuiltIn);
+            CFXFilterEffect::getId(), EffectBackendType::BuiltIn);
     auto defaultQuickEffectChainPreset =
             EffectChainPresetPointer(pDefaultQuickEffectManifest
                             ? new EffectChainPreset(pDefaultQuickEffectManifest)

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1,5 +1,7 @@
 #include "engine/controls/cuecontrol.h"
 
+#include <algorithm>
+
 #include "control/controlindicator.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
@@ -201,6 +203,27 @@ void CueControl::createControls() {
     m_pHotcueFocusColorNext = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "hotcue_focus_color_next"));
 
+    m_pMemoryCueSet = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_set"));
+    m_pMemoryCueSet->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueDelete = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_delete"));
+    m_pMemoryCueDelete->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCuePrev = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_prev"));
+    m_pMemoryCuePrev->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueNext = std::make_unique<ControlPushButton>(
+        ConfigKey(m_group, "memorycue_next"));
+    m_pMemoryCueNext->setButtonMode(ControlPushButton::TRIGGER);
+    m_pMemoryCueSelected = std::make_unique<ControlObject>(
+        ConfigKey(m_group, "memorycue_selected"));
+    m_pMemoryCueSelected->setReadOnly();
+    m_pMemoryCueSelected->forceSet(0.0);
+    m_pMemoryCueCount =
+        std::make_unique<ControlObject>(ConfigKey(m_group, "memorycue_count"));
+    m_pMemoryCueCount->setReadOnly();
+    m_pMemoryCueCount->forceSet(0.0);
+
     // Create hotcue controls
     for (int i = 0; i < m_iNumHotCues; ++i) {
         HotcueControl* pControl = new HotcueControl(m_group, i);
@@ -334,6 +357,15 @@ void CueControl::connectControls() {
             &CueControl::hotcueFocusColorNext,
             Qt::DirectConnection);
 
+    connect(m_pMemoryCueSet.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueSet, Qt::DirectConnection);
+    connect(m_pMemoryCueDelete.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueDelete, Qt::DirectConnection);
+    connect(m_pMemoryCuePrev.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCuePrev, Qt::DirectConnection);
+    connect(m_pMemoryCueNext.get(), &ControlObject::valueChanged, this,
+            &CueControl::memoryCueNext, Qt::DirectConnection);
+
     // Hotcue controls
     for (const auto& pControl : std::as_const(m_hotcueControls)) {
         connect(pControl, &HotcueControl::hotcuePositionChanged,
@@ -420,6 +452,10 @@ void CueControl::disconnectControls() {
 
     disconnect(m_pHotcueFocusColorPrev.get(), nullptr, this, nullptr);
     disconnect(m_pHotcueFocusColorNext.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueSet.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueDelete.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCuePrev.get(), nullptr, this, nullptr);
+    disconnect(m_pMemoryCueNext.get(), nullptr, this, nullptr);
 
     for (const auto& pControl : std::as_const(m_hotcueControls)) {
         disconnect(pControl, nullptr, this, nullptr);
@@ -493,6 +529,8 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         m_pOutroEndEnabled->forceSet(0.0);
         m_n60dBSoundStartPosition.setValue(Cue::kNoPosition);
         setHotcueFocusIndex(Cue::kNoHotCue);
+        setSelectedMemoryCue(nullptr);
+        m_pMemoryCueCount->forceSet(0.0);
         m_pLoadedTrack.reset();
         m_usedSeekOnLoadPosition.setValue(mixxx::audio::kStartFramePos);
     }
@@ -526,6 +564,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 
     // Update COs with cues from track.
     loadCuesFromTrack();
+    setSelectedMemoryCue(nullptr);
 
     // Seek track according to SeekOnLoadMode.
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
@@ -758,6 +797,7 @@ void CueControl::loadCuesFromTrack() {
     DEBUG_ASSERT(mainCuePosition.isValid());
     const auto quantizedMainCuePosition = quantizeCuePoint(mainCuePosition);
     m_pCuePoint->set(quantizedMainCuePosition.toEngineSamplePosMaybeInvalid());
+    updateMemoryCueState();
 }
 
 void CueControl::trackAnalyzed() {
@@ -1256,6 +1296,200 @@ void CueControl::hotcueClear(HotcueControl* pControl, double value) {
     detachCue(pControl);
     m_pLoadedTrack->removeCue(pCue);
     setHotcueFocusIndex(Cue::kNoHotCue);
+    updateMemoryCueState();
+}
+
+QList<HotcueControl *> CueControl::memoryCueControlsInPositionOrder() const {
+  QList<HotcueControl *> controls;
+  const int end = mixxx::kMemoryCueBankStart + mixxx::kMemoryCueBankSize;
+  for (int hotcueIndex = mixxx::kMemoryCueBankStart; hotcueIndex < end;
+       ++hotcueIndex) {
+    HotcueControl *pControl = m_hotcueControls.value(hotcueIndex, nullptr);
+    if (pControl && pControl->getPosition().isValid()) {
+      controls.append(pControl);
+    }
+  }
+  std::sort(controls.begin(), controls.end(),
+            [](const auto *pLeft, const auto *pRight) {
+              return pLeft->getPosition() < pRight->getPosition();
+            });
+  return controls;
+}
+
+HotcueControl *
+CueControl::memoryCueAtPosition(mixxx::audio::FramePos position) const {
+  if (!position.isValid()) {
+    return nullptr;
+  }
+
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  for (HotcueControl *pControl : controls) {
+    // FramePos is expressed in audio frames. Treat sub-frame differences as
+    // the same point so rounding at the engine-sample boundary is harmless.
+    if (fabs(pControl->getPosition() - position) < 0.5) {
+      return pControl;
+    }
+  }
+  return nullptr;
+}
+
+void CueControl::setMemoryCueAtMainCue(HotcueControl *pControl, double value,
+                                       mixxx::audio::FramePos position) {
+  auto lock = lockMutex(&m_trackMutex);
+  if (!m_pLoadedTrack || !position.isValid()) {
+    return;
+  }
+
+  hotcueClear(pControl, value);
+
+  const int hotcueIndex = pControl->getHotcueIndex();
+  mixxx::RgbColor color = mixxx::PredefinedColorPalettes::kDefaultCueColor;
+  ConfigKey autoHotcueColorsKey("[Controls]", "auto_hotcue_colors");
+  if (getConfig()->getValue(autoHotcueColorsKey, false)) {
+    color = m_colorPaletteSettings.getHotcueColorPalette().colorForHotcueIndex(
+        hotcueIndex);
+  } else {
+    color = colorFromConfig(ConfigKey("[Controls]", "HotcueDefaultColorIndex"));
+  }
+
+  CuePointer pCue = m_pLoadedTrack->createAndAddCue(
+      mixxx::CueType::HotCue, hotcueIndex, position,
+      mixxx::audio::kInvalidFramePos, color);
+  attachCue(pCue, pControl);
+}
+
+void CueControl::setSelectedMemoryCue(HotcueControl *pControl) {
+  if (pControl) {
+    const int hotcueIndex = pControl->getHotcueIndex();
+    VERIFY_OR_DEBUG_ASSERT(hotcueIndex >= mixxx::kMemoryCueBankStart &&
+                           hotcueIndex < mixxx::kMemoryCueBankStart +
+                                             mixxx::kMemoryCueBankSize) {
+      return;
+    }
+    m_selectedMemoryCueIndex = hotcueIndex;
+    m_pMemoryCueSelected->forceSet(hotcueIndex - mixxx::kMemoryCueBankStart +
+                                   1);
+  } else {
+    m_selectedMemoryCueIndex = Cue::kNoHotCue;
+    m_pMemoryCueSelected->forceSet(0.0);
+  }
+}
+
+void CueControl::updateMemoryCueState() {
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  m_pMemoryCueCount->forceSet(controls.size());
+  if (m_selectedMemoryCueIndex == Cue::kNoHotCue) {
+    return;
+  }
+  HotcueControl *pSelected =
+      m_hotcueControls.value(m_selectedMemoryCueIndex, nullptr);
+  if (!pSelected || !pSelected->getPosition().isValid()) {
+    setSelectedMemoryCue(nullptr);
+  }
+}
+
+void CueControl::callAdjacentMemoryCue(int direction) {
+  const QList<HotcueControl *> controls = memoryCueControlsInPositionOrder();
+  if (controls.isEmpty()) {
+    setSelectedMemoryCue(nullptr);
+    return;
+  }
+
+  const mixxx::audio::FramePos currentPosition = frameInfo().currentPosition;
+  if (!currentPosition.isValid()) {
+    return;
+  }
+
+  HotcueControl *pTarget = nullptr;
+  if (direction > 0) {
+    for (HotcueControl *pControl : controls) {
+      if (pControl->getPosition() - currentPosition > 0.5) {
+        pTarget = pControl;
+        break;
+      }
+    }
+  } else {
+    for (auto it = controls.crbegin(); it != controls.crend(); ++it) {
+      if (currentPosition - (*it)->getPosition() > 0.5) {
+        pTarget = *it;
+        break;
+      }
+    }
+  }
+
+  // Do not wrap at either end of the track.
+  if (!pTarget) {
+    return;
+  }
+  setSelectedMemoryCue(pTarget);
+  // Memory Cue CALL is a head-positioning operation, not a performance
+  // trigger: stop and seek exactly instead of using hotcue_activate.
+  hotcueGotoAndStop(pTarget, 1.0);
+}
+
+void CueControl::memoryCueSet(double value) {
+  if (value <= 0) {
+    return;
+  }
+
+  const bool loopEnabled = m_pLoopEnabled->toBool();
+  const mixxx::audio::FramePos position =
+      loopEnabled ? mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        m_pLoopStartPosition->get())
+                  : mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                        m_pCuePoint->get());
+  if (!position.isValid()) {
+    return;
+  }
+  if (memoryCueAtPosition(position)) {
+    return;
+  }
+
+  const int end = mixxx::kMemoryCueBankStart + mixxx::kMemoryCueBankSize;
+  for (int hotcueIndex = mixxx::kMemoryCueBankStart; hotcueIndex < end;
+       ++hotcueIndex) {
+    HotcueControl *pControl = m_hotcueControls.value(hotcueIndex, nullptr);
+    if (pControl && pControl->getStatus() == HotcueControl::Status::Empty) {
+      if (loopEnabled) {
+        hotcueSet(pControl, value, HotcueSetMode::Loop);
+      } else {
+        setMemoryCueAtMainCue(pControl, value, position);
+      }
+      // Storing a Memory Cue does not CALL it. Leave navigation unselected so
+      // the next CALL is not constrained by the newly stored cue's bank slot.
+      setSelectedMemoryCue(nullptr);
+      updateMemoryCueState();
+      return;
+    }
+  }
+}
+
+void CueControl::memoryCueDelete(double value) {
+  if (value <= 0) {
+    return;
+  }
+
+  HotcueControl *pControl = memoryCueAtPosition(frameInfo().currentPosition);
+  if (!pControl) {
+    setSelectedMemoryCue(nullptr);
+    return;
+  }
+  setSelectedMemoryCue(pControl);
+  hotcueClear(pControl, value);
+  setSelectedMemoryCue(nullptr);
+  updateMemoryCueState();
+}
+
+void CueControl::memoryCuePrev(double value) {
+  if (value > 0) {
+    callAdjacentMemoryCue(-1);
+  }
+}
+
+void CueControl::memoryCueNext(double value) {
+  if (value > 0) {
+    callAdjacentMemoryCue(1);
+  }
 }
 
 void CueControl::hotcuePositionChanged(

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -241,6 +241,11 @@ class CueControl : public EngineControl {
     void hotcueFocusColorNext(double v);
     void hotcueFocusColorPrev(double v);
 
+    void memoryCueSet(double v);
+    void memoryCueDelete(double v);
+    void memoryCuePrev(double v);
+    void memoryCueNext(double v);
+
     void passthroughChanged(double v);
 
     void cueSet(double v);
@@ -298,6 +303,13 @@ class CueControl : public EngineControl {
     void seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition);
     void setHotcueFocusIndex(int hotcueIndex);
     int getHotcueFocusIndex() const;
+    QList<HotcueControl *> memoryCueControlsInPositionOrder() const;
+    HotcueControl *memoryCueAtPosition(mixxx::audio::FramePos position) const;
+    void setMemoryCueAtMainCue(HotcueControl *pControl, double value,
+                               mixxx::audio::FramePos position);
+    void callAdjacentMemoryCue(int direction);
+    void setSelectedMemoryCue(HotcueControl *pControl);
+    void updateMemoryCueState();
     mixxx::RgbColor colorFromConfig(const ConfigKey& configKey);
 
     UserSettingsPointer m_pConfig;
@@ -372,6 +384,16 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlObject> m_pHotcueFocus;
     std::unique_ptr<ControlPushButton> m_pHotcueFocusColorNext;
     std::unique_ptr<ControlPushButton> m_pHotcueFocusColorPrev;
+
+    // Pioneer-style navigation over the reserved hotcue_17..26 storage bank.
+    // Keeping the storage compatible with Mixxx avoids a CueType/DB fork.
+    std::unique_ptr<ControlPushButton> m_pMemoryCueSet;
+    std::unique_ptr<ControlPushButton> m_pMemoryCueDelete;
+    std::unique_ptr<ControlPushButton> m_pMemoryCuePrev;
+    std::unique_ptr<ControlPushButton> m_pMemoryCueNext;
+    std::unique_ptr<ControlObject> m_pMemoryCueSelected;
+    std::unique_ptr<ControlObject> m_pMemoryCueCount;
+    int m_selectedMemoryCueIndex{Cue::kNoHotCue};
 
     parented_ptr<ControlProxy> m_pPassthrough;
 

--- a/src/library/librarycolumncontrol.h
+++ b/src/library/librarycolumncontrol.h
@@ -19,11 +19,9 @@ class WTrackTableViewHeader;
 // trigger is the [Library],column_visible_<name> + column_weight_<name>
 // ControlObjects set by the skin.
 //
-// The per-model header_state_pb (which the upstream menu writes) is unreachable
-// from the touch UI. This class wins over the protobuf for visibility and
-// width — column order and sort indicator still come from the protobuf
-// restore path in WTrackTableViewHeader, so those upstream behaviors are
-// preserved.
+// WTrackTableViewHeader saves/restores column order using the upstream
+// per-model header_state_pb. This class applies visibility and weighted
+// widths after that restore, overriding the protobuf's layout dimensions.
 //
 // Width semantics: each visible column has an integer weight (1..4). On
 // every apply pass the visible weights are summed and each column is sized

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -6,11 +6,13 @@
 #include <rekordbox_anlz.h>
 #include <rekordbox_pdb.h>
 
+#include <QDir>
 #include <QMap>
 #include <QMessageBox>
 #include <QSet>
 #include <QSettings>
 #include <QString>
+#include <QStringList>
 #include <QTextCodec>
 #include <QtDebug>
 #include <vector>
@@ -52,12 +54,28 @@ const QString kRekordboxLibraryTable = QStringLiteral("rekordbox_library");
 const QString kRekordboxPlaylistsTable = QStringLiteral("rekordbox_playlists");
 const QString kRekordboxPlaylistTracksTable = QStringLiteral("rekordbox_playlist_tracks");
 
-const QString kPdbPath = QStringLiteral("PIONEER/rekordbox/export.pdb");
+// depending on the filesystem of the external media, rekordbox seems
+// to store its metadata in different paths:
+const QStringList kPdbPaths = {
+        QStringLiteral("PIONEER/rekordbox/export.pdb"),  // FAT32/exFat
+        QStringLiteral(".PIONEER/rekordbox/export.pdb"), // HFS+ media
+};
 const QString kPLaylistPathDelimiter = QStringLiteral("-->");
 
 // Consecutive empty background enumerations required before a device is
 // removed from the sidebar and its rows cleared.
 constexpr int kBgEmptyScansBeforeRemoval = 3;
+
+QString findRekordboxPdbPath(const QString& devicePath) {
+    const QDir deviceDir(devicePath);
+    for (const auto& pdbPath : kPdbPaths) {
+        const QFileInfo pdbFileInfo(deviceDir.filePath(pdbPath));
+        if (pdbFileInfo.exists() && pdbFileInfo.isFile()) {
+            return pdbFileInfo.filePath();
+        }
+    }
+    return {};
+}
 
 enum class IDForColor : uint8_t {
     Pink = 1,
@@ -205,9 +223,7 @@ QList<TreeItem*> findRekordboxDevices() {
         // drive.filePath() doesn't make any access to the filesystem and consequently
         // shorten the delay
 
-        QFileInfo rbDBFileInfo(drive.filePath() + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(drive.filePath()).isEmpty()) {
             QString displayPath = drive.filePath();
             if (displayPath.endsWith("/")) {
                 displayPath.chop(1);
@@ -261,9 +277,7 @@ QList<TreeItem*> findRekordboxDevices() {
         }
         seenMountPoints.insert(canonicalPath);
 
-        QFileInfo rbDBFileInfo(device.filePath() + QStringLiteral("/") + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(device.filePath()).isEmpty()) {
             auto* pFoundDevice = new TreeItem(
                     device.fileName(),
                     QVariant(QList<QString>{device.filePath(), IS_RECORDBOX_DEVICE}));
@@ -274,9 +288,7 @@ QList<TreeItem*> findRekordboxDevices() {
     QFileInfoList devices = QDir(QStringLiteral("/Volumes")).entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
     foreach (QFileInfo device, devices) {
-        QFileInfo rbDBFileInfo(device.filePath() + QStringLiteral("/") + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(device.filePath()).isEmpty()) {
             QList<QString> data;
             data << device.filePath();
             data << IS_RECORDBOX_DEVICE;
@@ -507,9 +519,9 @@ QString parseDeviceDB(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dev
 
     qDebug() << "parseDeviceDB device: " << device << " devicePath: " << devicePath;
 
-    QString dbPath = devicePath + QStringLiteral("/") + kPdbPath;
+    const QString dbPath = findRekordboxPdbPath(devicePath);
 
-    if (!QFile(dbPath).exists()) {
+    if (dbPath.isEmpty()) {
         return devicePath;
     }
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -340,7 +340,9 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     m_pContext->setSkinBasePath(skinPath);
 
     if (m_pParent) {
-        qDebug() << "ERROR: Somehow a parent already exists -- you are probably re-using a LegacySkinParser which is not advisable!";
+        qDebug()
+                << "ERROR: Somehow a parent already exists -- you are probably "
+                   "reusing a LegacySkinParser which is not advisable!";
     }
     QDomElement skinDocument = openSkin(skinPath);
 
@@ -995,6 +997,8 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
     // effect which breaks color scheme support.
     pLabel->setup(element, *m_pContext);
     commonWidgetSetup(element, pLabel);
+    // OpenType features must be applied after the stylesheet selects the font.
+    pLabel->applyFontFeatures();
     pLabel->installEventFilter(m_pKeyboard);
     pLabel->installEventFilter(
             m_pControllerManager->getControllerLearningEventFilter());

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -40,6 +40,27 @@ class HotcueControlTest : public BaseSignalPathTest {
         m_pHotcue2Status = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_status");
         m_pHotcue2Position = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_position");
         m_pHotcue2EndPosition = std::make_unique<ControlProxy>(m_sGroup1, "hotcue_2_endposition");
+        m_pMemoryCue17Status =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_17_status");
+        m_pMemoryCue17Position =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_17_position");
+        m_pMemoryCue18Status =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_18_status");
+        m_pMemoryCue18Position =
+            std::make_unique<ControlProxy>(m_sGroup1, "hotcue_18_position");
+        m_pMemoryCueSet =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_set");
+        m_pMemoryCueDelete =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_delete");
+        m_pMemoryCuePrev =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_prev");
+        m_pMemoryCueNext =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_next");
+        m_pMemoryCueSelected =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_selected");
+        m_pMemoryCueCount =
+            std::make_unique<ControlProxy>(m_sGroup1, "memorycue_count");
+        m_pCueSet = std::make_unique<ControlProxy>(m_sGroup1, "cue_set");
         m_pQuantizeEnabled = std::make_unique<ControlProxy>(m_sGroup1, "quantize");
     }
 
@@ -118,8 +139,170 @@ class HotcueControlTest : public BaseSignalPathTest {
     std::unique_ptr<ControlProxy> m_pHotcue2Status;
     std::unique_ptr<ControlProxy> m_pHotcue2Position;
     std::unique_ptr<ControlProxy> m_pHotcue2EndPosition;
+    std::unique_ptr<ControlProxy> m_pMemoryCue17Status;
+    std::unique_ptr<ControlProxy> m_pMemoryCue17Position;
+    std::unique_ptr<ControlProxy> m_pMemoryCue18Status;
+    std::unique_ptr<ControlProxy> m_pMemoryCue18Position;
+    std::unique_ptr<ControlProxy> m_pMemoryCueSet;
+    std::unique_ptr<ControlProxy> m_pMemoryCueDelete;
+    std::unique_ptr<ControlProxy> m_pMemoryCuePrev;
+    std::unique_ptr<ControlProxy> m_pMemoryCueNext;
+    std::unique_ptr<ControlProxy> m_pMemoryCueSelected;
+    std::unique_ptr<ControlProxy> m_pMemoryCueCount;
+    std::unique_ptr<ControlProxy> m_pCueSet;
     std::unique_ptr<ControlProxy> m_pQuantizeEnabled;
 };
+
+TEST_F(HotcueControlTest, MemoryCueCallUsesPositionOrderAndStops) {
+  TrackPointer pTrack = createTestTrack();
+  const mixxx::audio::FramePos earlyPosition(3000);
+  const mixxx::audio::FramePos latePosition(9000);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue, mixxx::kMemoryCueBankStart,
+                          latePosition, mixxx::audio::kInvalidFramePos);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue,
+                          mixxx::kMemoryCueBankStart + 1, earlyPosition,
+                          mixxx::audio::kInvalidFramePos);
+  loadTrack(pTrack);
+
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  m_pPlay->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_FALSE(m_pPlay->toBool());
+  EXPECT_EQ(earlyPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(latePosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueSelected->get());
+
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(earlyPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+}
+
+TEST_F(HotcueControlTest, MemoryCueCallUsesCurrentPositionWithSingleCue) {
+  TrackPointer pTrack = createTestTrack();
+  const mixxx::audio::FramePos cuePosition(5000);
+  const mixxx::audio::FramePos beforePosition(1000);
+  const mixxx::audio::FramePos afterPosition(9000);
+  pTrack->createAndAddCue(mixxx::CueType::HotCue, mixxx::kMemoryCueBankStart,
+                          cuePosition, mixxx::audio::kInvalidFramePos);
+  loadTrack(pTrack);
+
+  setCurrentFramePosition(afterPosition);
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(cuePosition, currentFramePosition());
+
+  setCurrentFramePosition(beforePosition);
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(cuePosition, currentFramePosition());
+
+  setCurrentFramePosition(afterPosition);
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(afterPosition, currentFramePosition());
+
+  setCurrentFramePosition(beforePosition);
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(beforePosition, currentFramePosition());
+}
+
+TEST_F(HotcueControlTest, MemoryCueSetAndDeleteUseReservedBank) {
+  createAndLoadFakeTrack();
+  const mixxx::audio::FramePos cuePosition(5000);
+  const mixxx::audio::FramePos playPosition(9000);
+  setCurrentFramePosition(cuePosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  setCurrentFramePosition(playPosition);
+
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue17Status->get());
+  EXPECT_EQ(cuePosition.toEngineSamplePos(), m_pMemoryCue17Position->get());
+  EXPECT_EQ(playPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  setCurrentFramePosition(cuePosition);
+  m_pMemoryCueDelete->set(1.0);
+  ProcessBuffer();
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+                   m_pMemoryCue17Status->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+}
+
+TEST_F(HotcueControlTest,
+       MemoryCueSetAtExistingPositionDoesNotDuplicateAndDeleteUsesPosition) {
+  createAndLoadFakeTrack();
+  const mixxx::audio::FramePos firstPosition(5000);
+  const mixxx::audio::FramePos secondPosition(9000);
+
+  setCurrentFramePosition(firstPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(0.0);
+
+  setCurrentFramePosition(secondPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(0.0);
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  EXPECT_DOUBLE_EQ(0.0, m_pMemoryCueSelected->get());
+
+  // Select the second cue through CALL, then return to the first cue position.
+  // A duplicate SET must not adopt the first cue as the selection.
+  setCurrentFramePosition(mixxx::audio::FramePos(12000));
+  m_pMemoryCuePrev->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(secondPosition, currentFramePosition());
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+
+  setCurrentFramePosition(firstPosition);
+  m_pCueSet->set(1.0);
+  ProcessBuffer();
+  m_pMemoryCueSet->set(1.0);
+  ProcessBuffer();
+
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueCount->get());
+  // A duplicate SET is a no-op, including the prior selection state.
+  EXPECT_DOUBLE_EQ(2.0, m_pMemoryCueSelected->get());
+  EXPECT_EQ(firstPosition.toEngineSamplePos(), m_pMemoryCue17Position->get());
+  EXPECT_EQ(secondPosition.toEngineSamplePos(), m_pMemoryCue18Position->get());
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue18Status->get());
+
+  m_pMemoryCueDelete->set(1.0);
+  ProcessBuffer();
+  // DELETE resolves its target from the current position, not the previously
+  // selected memory cue.
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+                   m_pMemoryCue17Status->get());
+  EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+                   m_pMemoryCue18Status->get());
+  EXPECT_DOUBLE_EQ(1.0, m_pMemoryCueCount->get());
+
+  // DELETE clears the selection, but NEXT still resolves from the deleted
+  // cue's position and reaches the remaining cue.
+  m_pMemoryCueNext->set(1.0);
+  ProcessBuffer();
+  EXPECT_EQ(secondPosition, currentFramePosition());
+}
 
 TEST_F(HotcueControlTest, DefautltControlValues) {
     TrackPointer pTrack = createTestTrack();

--- a/src/test/librarycolumncontrol_test.cpp
+++ b/src/test/librarycolumncontrol_test.cpp
@@ -1,6 +1,7 @@
 // Tests for the Bite DJ LibraryColumnControl-managed track table layout:
 // managed visibility/weights from mixxx.cfg, internal-column enforcement,
-// self-healing after model resets, and the rating column's minimum width.
+// self-healing after model resets, upstream-compatible order persistence,
+// and the rating column's minimum width.
 #include <gtest/gtest.h>
 
 #include <QApplication>
@@ -154,6 +155,8 @@ TEST_F(LibraryColumnControlTest, ManagedLayoutIsAppliedAndSelfHealing) {
             model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING);
     const int titleCol =
             model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+    const int artistCol =
+            model.fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST);
 
     // Managed layout per config: '#' (position), title, rating visible;
     // preview managed-invisible; internal track_id hidden.
@@ -186,4 +189,24 @@ TEST_F(LibraryColumnControlTest, ManagedLayoutIsAppliedAndSelfHealing) {
     EXPECT_TRUE(header->isSectionHidden(previewCol));
     EXPECT_FALSE(header->isSectionHidden(positionCol));
     EXPECT_GE(header->sectionSize(ratingCol), StarRating().sizeHint().width());
+
+    // Column order uses the upstream per-model header state, while a restored
+    // pixel width is replaced by BiteDJ's configured weight.
+    const int artistVisualIndex = header->visualIndex(artistCol);
+    header->moveSection(header->visualIndex(titleCol), artistVisualIndex);
+    header->resizeSection(titleCol, 37);
+
+    QTableView restoredView;
+    restoredView.resize(800, 480);
+    auto* restoredHeader =
+            new WTrackTableViewHeader(Qt::Horizontal, &restoredView);
+    restoredView.setModel(&model);
+    restoredView.setHorizontalHeader(restoredHeader);
+    restoredView.show();
+    QApplication::processEvents();
+
+    EXPECT_EQ(artistVisualIndex, restoredHeader->visualIndex(titleCol));
+    EXPECT_NE(37, restoredHeader->sectionSize(titleCol));
+    EXPECT_TRUE(restoredHeader->isSectionHidden(trackIdCol));
+    EXPECT_TRUE(restoredHeader->isSectionHidden(previewCol));
 }

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -38,15 +38,17 @@ static constexpr int kFirstHotCueIndex = 0;
 /// `hotcue_N_*` controls, so the engine treats them identically; only the
 /// importer and the skin care which bank a cue lives in.
 ///
-/// Hot cue bank: rekordbox pads A-H, and the eight pads a controller maps.
+/// Hot cue bank: rekordbox pads A-P. Controllers with eight physical pads
+/// address A-H directly while the remaining slots stay available to the
+/// library, waveform and mappings that provide a second page.
 static constexpr int kHotCueBankStart = kFirstHotCueIndex;
-static constexpr int kHotCueBankSize = 8;
+static constexpr int kHotCueBankSize = 16;
 
 /// Memory cue bank: chronological, the first of which also becomes the main
 /// cue. Starts clear of the hot cue bank so that growing one never shifts the
 /// other.
 static constexpr int kMemoryCueBankStart = 16;
-static constexpr int kMemoryCueBankSize = 8;
+static constexpr int kMemoryCueBankSize = 10;
 
 // DTO for Cue information without dependencies on the actual Track object
 class CueInfo {

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -2,6 +2,7 @@
 
 #include <QEvent>
 #include <QFont>
+#include <QtGlobal>
 
 #include "moc_wlabel.cpp"
 #include "skin/legacy/skincontext.h"
@@ -20,6 +21,7 @@ WLabel::WLabel(QWidget* pParent)
 
 void WLabel::setup(const QDomNode& node, const SkinContext& context) {
     m_scaleFactor = context.getScaleFactor();
+    m_bTabularNumbers = context.selectBool(node, "TabularNumbers", false);
 
     // Colors
     QPalette pal = palette(); // we have to copy out the palette to edit it since it's const (probably for threadsafety)
@@ -87,6 +89,19 @@ void WLabel::setup(const QDomNode& node, const SkinContext& context) {
                     "unknown, use right, middle, left or none.";
         }
     }
+}
+
+void WLabel::applyFontFeatures() {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    if (m_bTabularNumbers) {
+        // OpenType's "tnum" feature gives every digit the same advance width,
+        // preventing changing numeric text from shifting. Apply it after skin
+        // styling so the selected font keeps this feature.
+        QFont tabularFont = font();
+        tabularFont.setFeature("tnum", 1);
+        setFont(tabularFont);
+    }
+#endif
 }
 
 QString WLabel::text() const {

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -13,6 +13,7 @@ class WLabel : public QLabel, public WBaseWidget {
     explicit WLabel(QWidget* pParent=nullptr);
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
+    void applyFontFeatures();
 
     QString text() const;
     void setText(const QString& text);
@@ -38,6 +39,8 @@ class WLabel : public QLabel, public WBaseWidget {
     // Foreground and background colors.
     QColor m_qFgColor;
     QColor m_qBgColor;
+    bool m_bTabularNumbers{false};
+
   private:
     QString m_longText;
     Qt::TextElideMode m_elideMode;

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -1,5 +1,7 @@
 #include "widget/wnumberpos.h"
 
+#include <QMouseEvent>
+
 #include "control/controlproxy.h"
 #include "moc_wnumberpos.cpp"
 #include "util/duration.h"
@@ -26,6 +28,24 @@ WNumberPos::WNumberPos(const QString& group, QWidget* parent)
     m_pTimeFormat->connectValueChanged(
             this, &WNumberPos::slotSetTimeFormat);
     slotSetTimeFormat(m_pTimeFormat->get());
+}
+
+void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
+    bool leftClick = pEvent->buttons() & Qt::LeftButton;
+
+    if (leftClick) {
+        // Cycle through display modes
+        if (m_displayMode == TrackTime::DisplayMode::ELAPSED) {
+            m_displayMode = TrackTime::DisplayMode::REMAINING;
+        } else if (m_displayMode == TrackTime::DisplayMode::REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED_AND_REMAINING;
+        } else if (m_displayMode == TrackTime::DisplayMode::ELAPSED_AND_REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED;
+        }
+
+        m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
+        slotSetTimeElapsed(m_dOldTimeElapsed);
+    }
 }
 
 // Reimplementing WNumber::setValue

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -43,6 +43,12 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
             m_displayMode = TrackTime::DisplayMode::ELAPSED;
         }
 
+        // BiteDJ has a single track-time field, so skip Mixxx's combined
+        // elapsed-and-remaining mode without rewriting the upstream cycle.
+        if (m_displayMode == TrackTime::DisplayMode::ELAPSED_AND_REMAINING) {
+            m_displayMode = TrackTime::DisplayMode::ELAPSED;
+        }
+
         m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
         slotSetTimeElapsed(m_dOldTimeElapsed);
     }

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -12,6 +12,9 @@ class WNumberPos : public WNumber {
   public:
     explicit WNumberPos(const QString& group, QWidget* parent = nullptr);
 
+  protected:
+    void mousePressEvent(QMouseEvent* pEvent) override;
+
   private slots:
     void setValue(double dValue) override;
     void slotSetTimeElapsed(double);

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -26,7 +26,6 @@ class WNumberPos : public WNumber {
 
     TrackTime::DisplayMode m_displayMode;
     TrackTime::DisplayFormat m_displayFormat;
-
     double m_dOldTimeElapsed;
     ControlProxy* m_pTimeElapsed;
     ControlProxy* m_pTimeRemaining;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -24,7 +24,6 @@
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
-#include "widget/timeremainingoverlay.h"
 #include "wskincolor.h"
 
 namespace {
@@ -74,18 +73,7 @@ WOverview::WOverview(
                   QStringLiteral("track_samples")),
           m_playpositionControl(
                   m_group,
-                  QStringLiteral("playposition")),
-          m_timeRemainingControl(
-                  m_group,
-                  QStringLiteral("time_remaining")),
-          m_timeRemainingColor(Qt::white),
-          m_timeRemainingBackgroundColor(
-                  0, 0, 0, TimeRemainingOverlay::kDefaultBackgroundAlpha),
-          m_timeRemainingOpacity(TimeRemainingOverlay::kDefaultOpacity),
-          m_timeRemainingScale(TimeRemainingOverlay::kDefaultScale),
-          m_timeRemainingAlign(Qt::AlignHCenter | Qt::AlignVCenter),
-          m_bTimeRemainingVisible(true),
-          m_iTimeRemainingSeconds(0) {
+                  QStringLiteral("playposition")) {
     m_endOfTrackControl = make_parented<ControlProxy>(
             m_group, QStringLiteral("end_of_track"), this, ControlFlag::NoAssertIfMissing);
     m_endOfTrackControl->connectValueChanged(this, &WOverview::onEndOfTrackChange);
@@ -167,36 +155,6 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
                 context.makeSkinPath(m_backgroundPixmapPath),
                 m_scaleFactor);
     }
-
-    // Time-remaining watermark. Defaults are in timeremainingoverlay.h; a skin
-    // only needs these nodes to deviate from them.
-    const QString timeRemainingColorName =
-            context.selectString(node, "TimeRemainingColor");
-    if (!timeRemainingColorName.isEmpty()) {
-        m_timeRemainingColor =
-                WSkinColor::getCorrectColor(QColor(timeRemainingColorName));
-    }
-    const QString timeRemainingBgColorName =
-            context.selectString(node, "TimeRemainingBgColor");
-    if (!timeRemainingBgColorName.isEmpty()) {
-        // Keep the alpha the skin asked for; getCorrectColor() would drop it.
-        m_timeRemainingBackgroundColor = QColor(timeRemainingBgColorName);
-    }
-    m_timeRemainingOpacity = math_clamp(
-            context.selectDouble(node,
-                    "TimeRemainingOpacity",
-                    TimeRemainingOverlay::kDefaultOpacity),
-            0.0,
-            1.0);
-    const double timeRemainingScale = context.selectDouble(node,
-            "TimeRemainingScale",
-            TimeRemainingOverlay::kDefaultScale);
-    if (timeRemainingScale > 0.0) {
-        m_timeRemainingScale = timeRemainingScale;
-    }
-    m_timeRemainingAlign = TimeRemainingOverlay::decodeAlign(
-            context.selectString(node, "TimeRemainingAlign"),
-            Qt::AlignHCenter | Qt::AlignVCenter);
 
     m_endOfTrackColor = QColor(200, 25, 20);
     const QString endOfTrackColorName = context.selectString(node, "EndOfTrackColor");
@@ -326,15 +284,6 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
     int oldPositionSeconds = m_iPosSeconds;
     m_iPosSeconds = static_cast<int>(dParameter * getTrackSamples());
     if ((m_bTimeRulerActive || m_pHoveredMark != nullptr) && oldPositionSeconds != m_iPosSeconds) {
-        redraw = true;
-    }
-
-    // The time-remaining watermark shows whole seconds, and on a short overview
-    // one pixel of play marker can span several of them. Redraw on the digits
-    // changing too, or the countdown would visibly skip.
-    const int oldTimeRemainingSeconds = m_iTimeRemainingSeconds;
-    m_iTimeRemainingSeconds = static_cast<int>(std::ceil(m_timeRemainingControl.get()));
-    if (m_bTimeRemainingVisible && oldTimeRemainingSeconds != m_iTimeRemainingSeconds) {
         redraw = true;
     }
 
@@ -736,8 +685,6 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
             drawTimeRuler(&painter);
             drawMarkLabels(&painter, offset, gain);
         }
-        // Last, so the watermark sits over every other layer.
-        drawTimeRemaining(&painter);
     }
 
     if (m_bPassthroughEnabled) {
@@ -1332,96 +1279,6 @@ void WOverview::drawMarkLabels(QPainter* pPainter, const float offset, const flo
             }
         }
     }
-}
-
-void WOverview::setTimeRemainingVisible(bool visible) {
-    if (m_bTimeRemainingVisible == visible) {
-        return;
-    }
-    m_bTimeRemainingVisible = visible;
-    update();
-}
-
-/// The part of the widget an ancestor doesn't cut off, in widget coordinates.
-/// A skin may hand the overview a widget taller than the room its container
-/// leaves it — deck.xml lays the summary out at double height and shows the
-/// top half of it — so the widget's own rect is not what the DJ can see. Only
-/// ancestor geometry is taken into account, not overlapping siblings: this
-/// decides where text is laid out, and that must not move when something else
-/// happens to be drawn over the strip.
-QRect WOverview::visibleStripRect() const {
-    QRect visible = rect();
-    for (const QWidget* pAncestor = parentWidget(); pAncestor != nullptr;
-            pAncestor = pAncestor->parentWidget()) {
-        visible &= pAncestor->rect().translated(-mapTo(pAncestor, QPoint(0, 0)));
-        if (pAncestor->isWindow()) {
-            break;
-        }
-    }
-    return visible;
-}
-
-void WOverview::drawTimeRemaining(QPainter* pPainter) {
-    if (!m_bTimeRemainingVisible) {
-        return;
-    }
-
-    const double remainingSeconds = m_timeRemainingControl.get();
-    if (remainingSeconds < 0.0) {
-        return;
-    }
-
-    const QRect visible = visibleStripRect();
-    if (visible.isEmpty()) {
-        return;
-    }
-    // Sized and placed against what is on screen rather than against the whole
-    // widget, so a clipped overview keeps the digits inside the strip instead
-    // of centring them on an edge.
-    const bool horizontal = m_orientation == Qt::Horizontal;
-    const qreal visibleLength = horizontal ? visible.width() : visible.height();
-    const qreal visibleBreadth = horizontal ? visible.height() : visible.width();
-
-    const QString text = TimeRemainingOverlay::remainingTimeToString(remainingSeconds);
-    const TimeRemainingOverlay::TextLayout layout = TimeRemainingOverlay::layoutFor(
-            text, visibleBreadth, visibleLength, m_timeRemainingScale);
-    if (!layout.valid) {
-        return;
-    }
-
-    float x, y;
-    TimeRemainingOverlay::alignedPosition(m_timeRemainingAlign,
-            static_cast<float>(visibleLength),
-            static_cast<float>(visibleBreadth),
-            static_cast<float>(layout.boxWidth()),
-            static_cast<float>(layout.boxHeight()),
-            &x,
-            &y);
-
-    PainterScope painterScope(pPainter);
-    if (m_orientation == Qt::Vertical) {
-        // length()/breadth() run along the overview, not the widget. This is
-        // the same rotation the mark labels use to follow it.
-        pPainter->translate(width(), 0);
-        pPainter->rotate(90.0);
-        // In that frame the axes run from the widget's top edge and its right
-        // edge, which is where the visible strip has to be measured from too.
-        x += static_cast<float>(visible.top());
-        y += static_cast<float>(width() - visible.right() - 1);
-    } else {
-        x += static_cast<float>(visible.left());
-        y += static_cast<float>(visible.top());
-    }
-    pPainter->translate(x, y);
-    // The whole overlay is drawn at this opacity so the summary stays visible
-    // through it.
-    pPainter->setOpacity(m_timeRemainingOpacity);
-
-    TimeRemainingOverlay::paintOverlay(pPainter,
-            layout,
-            text,
-            m_timeRemainingColor,
-            m_timeRemainingBackgroundColor);
 }
 
 void WOverview::drawPassthroughOverlay(QPainter* pPainter) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -461,12 +461,14 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
             if ((currentCue->getType() == mixxx::CueType::HotCue ||
                         currentCue->getType() == mixxx::CueType::Loop) &&
                     hotcueNumber != Cue::kNoHotCue) {
-                // Prepend the hotcue number to hotcues' labels
+                // Prepend the skin-defined hotcue prefix to hotcues' labels.
+                // This falls back to the hotcue number when no prefix is set.
                 QString newLabel = currentCue->getLabel();
                 if (newLabel.isEmpty()) {
-                    newLabel = QString::number(hotcueNumber + 1);
+                    newLabel = pMark->hotcueLabelPrefix();
                 } else {
-                    newLabel = QString("%1: %2").arg(hotcueNumber + 1).arg(newLabel);
+                    newLabel = QString("%1: %2")
+                                       .arg(pMark->hotcueLabelPrefix(), newLabel);
                 }
 
                 if (pMark->m_text != newLabel) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -22,12 +22,6 @@ class SkinContext;
 
 class WOverview : public WWidget, public TrackDropTarget {
     Q_OBJECT
-    /// Whether the time-remaining watermark is painted. The summary only stands
-    /// in for the scrolling waveform on the pages that don't carry one, so the
-    /// skin binds this to the tab it is on rather than to anything about the
-    /// deck. Defaults to on, so a skin that never binds it is unaffected.
-    Q_PROPERTY(bool timeRemainingVisible READ timeRemainingVisible WRITE
-                    setTimeRemainingVisible)
   public:
     WOverview(
             const QString& group,
@@ -38,10 +32,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     void setup(const QDomNode& node, const SkinContext& context);
     virtual void initWithTrack(TrackPointer pTrack);
 
-    bool timeRemainingVisible() const {
-        return m_bTimeRemainingVisible;
-    }
-    void setTimeRemainingVisible(bool visible);
 
     enum class Type {
         Filtered,
@@ -113,8 +103,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     void drawPickupPosition(QPainter* pPainter);
     void drawTimeRuler(QPainter* pPainter);
     void drawMarkLabels(QPainter* pPainter, const float offset, const float gain);
-    QRect visibleStripRect() const;
-    void drawTimeRemaining(QPainter* pPainter);
     void drawPassthroughOverlay(QPainter* pPainter);
     void paintText(const QString& text, QPainter* pPainter);
     double samplePositionToSeconds(double sample);
@@ -211,7 +199,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     PollingControlProxy m_trackSampleRateControl;
     PollingControlProxy m_trackSamplesControl;
     PollingControlProxy m_playpositionControl;
-    PollingControlProxy m_timeRemainingControl;
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
 
@@ -231,15 +218,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     QColor m_passthroughOverlayColor;
     QColor m_playedOverlayColor;
     QColor m_lowColor;
-    QColor m_timeRemainingColor;
-    QColor m_timeRemainingBackgroundColor;
-    double m_timeRemainingOpacity;
-    double m_timeRemainingScale;
-    Qt::Alignment m_timeRemainingAlign;
-    bool m_bTimeRemainingVisible;
-    /// Whole seconds left, so paints can be forced when the digits change
-    /// rather than only when the play marker crosses a pixel.
-    int m_iTimeRemainingSeconds;
     int m_dimBrightThreshold;
     parented_ptr<QLabel> m_pPassthroughLabel;
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -271,15 +271,11 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* pNewModel, bool restore
 
     setModel(pNewModel);
     setHorizontalHeader(header);
-    // Bite DJ fork: when LibraryColumnControl owns column visibility +
-    // widths, also lock the order and disable user drag-resize. Reorders
-    // wouldn't survive restart (we no longer save the per-model protobuf)
-    // and drag-resize would silently get clobbered by the next flex-weight
-    // re-apply on header resize — both are confusing transient UX. Fixed
-    // resize mode still permits programmatic resizeSection(), which is
-    // what LibraryColumnControl::applyTo uses.
+    // Use Qt's drag reordering and the upstream per-model header state.
+    // BiteDJ's weighted widths still own resizing; Fixed permits the
+    // programmatic resizeSection() calls made by LibraryColumnControl.
     const bool columnControlActive = LibraryColumnControl::tryInstance() != nullptr;
-    header->setSectionsMovable(!columnControlActive);
+    header->setSectionsMovable(true);
     if (columnControlActive) {
         header->setSectionResizeMode(QHeaderView::Fixed);
     }

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -2,6 +2,7 @@
 
 #include <QCheckBox>
 #include <QContextMenuEvent>
+#include <QScopedValueRollback>
 #include <QWidgetAction>
 
 #include "library/librarycolumncontrol.h"
@@ -82,7 +83,7 @@ QString HeaderViewState::saveState() const {
     if(m_view_state.SerializeToArray(array.data(), size)) {
         return QString(array.toBase64());
     } else {
-        qWarning() << "Could not serialze m_view_state to QByteArray of size "
+        qWarning() << "Could not serialize m_view_state to QByteArray of size "
                    << array.size();
         return "";
     }
@@ -135,9 +136,16 @@ void HeaderViewState::restoreState(WTrackTableViewHeader* pHeaders) {
 WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
         QWidget* pParent)
         : QHeaderView(orientation, pParent),
-          m_menu(tr("Show or hide columns."), this) {
+          m_menu(tr("Show or hide columns."), this),
+          m_restoringHeaderState(false) {
     if (auto* pColumnControl = LibraryColumnControl::tryInstance()) {
         pColumnControl->registerHeader(this);
+        // The appliance may be powered off without the normal widget
+        // destruction path, so persist a completed Qt header drag at once.
+        connect(this,
+                &QHeaderView::sectionMoved,
+                this,
+                &WTrackTableViewHeader::slotSaveColumnOrder);
         // Whenever Qt re-initializes this header's sections (model reset,
         // column count change — the moments hidden-section state can be
         // dropped), re-assert the managed layout. The appliance has no
@@ -311,16 +319,8 @@ void WTrackTableViewHeader::saveHeaderState() {
     if (!pTrackModel) {
         return;
     }
-    // Bite DJ fork: when LibraryColumnControl is active, skip the
-    // per-model protobuf entirely. Visibility and widths are owned by
-    // mixxx.cfg via [Library],ColumnVisible_*/ColumnWeight_*; writing the
-    // protobuf would just snapshot pixel widths from a transient
-    // header.width() and re-apply that stale layout on next launch before
-    // our control overrides it. Tradeoff: per-model sort indicator and
-    // column order are no longer persisted across launches.
-    if (LibraryColumnControl::tryInstance()) {
-        return;
-    }
+    // Keep the upstream format for column order. BiteDJ re-applies its
+    // managed visibility and weighted widths after restoring this state.
     // Convert the QByteArray to a Base64 string and save it.
     HeaderViewState view_state(*this);
     pTrackModel->setModelSetting("header_state_pb", view_state.saveState());
@@ -333,23 +333,7 @@ void WTrackTableViewHeader::restoreHeaderState() {
     if (!pTrackModel) {
         return;
     }
-
-    // Bite DJ fork: LibraryColumnControl is the sole source of truth for
-    // visibility and widths. Skip the per-model protobuf restore — see
-    // saveHeaderState above for the why. Pre-hide hidden-by-default
-    // columns we don't manage (e.g. composer, bitrate) so the table isn't
-    // cluttered on first show; managed hidden-by-default columns
-    // (TimesPlayed, Year) get their final visibility from applyTo below.
-    if (auto* pColumnControl = LibraryColumnControl::tryInstance()) {
-        loadDefaultHeaderState();
-        for (int i = 0; i < count(); ++i) {
-            if (pTrackModel->isColumnHiddenByDefault(i)) {
-                setSectionHidden(i, true);
-            }
-        }
-        pColumnControl->applyTo(this);
-        return;
-    }
+    const QScopedValueRollback restoringGuard(m_restoringHeaderState, true);
 
     const QString headerStateString = pTrackModel->getModelSetting("header_state_pb");
     if (headerStateString.isNull()) {
@@ -364,6 +348,15 @@ void WTrackTableViewHeader::restoreHeaderState() {
         } else {
             view_state.restoreState(this);
         }
+    }
+    // Restore order first, then let BiteDJ's config override the saved
+    // pixel widths and visibility. This does not move any sections.
+    slotReapplyColumnControl();
+}
+
+void WTrackTableViewHeader::slotSaveColumnOrder() {
+    if (!m_restoringHeaderState) {
+        saveHeaderState();
     }
 }
 
@@ -402,7 +395,7 @@ void WTrackTableViewHeader::slotReapplyColumnControl() {
     if (!pColumnControl || !pTrackModel) {
         return;
     }
-    // Mirrors the column-control branch of restoreHeaderState: pre-hide the
+    // After restoring the header state or repopulating the model, pre-hide the
     // hidden-by-default columns we don't manage, then let the control apply
     // visibility, internal-column hiding and flex widths.
     for (int i = 0; i < count(); ++i) {

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -74,6 +74,7 @@ class WTrackTableViewHeader : public QHeaderView {
 
   private slots:
     void showOrHideColumn(int);
+    void slotSaveColumnOrder();
     void slotReapplyColumnControl();
 
   private:
@@ -84,4 +85,5 @@ class WTrackTableViewHeader : public QHeaderView {
     QMenu m_menu;
     QMap<int, QCheckBox*> m_columnCheckBoxes;
     QMap<int, int> m_hiddenColumnSizes;
+    bool m_restoringHeaderState;
 };


### PR DESCRIPTION
  ## Summary

  Use the skin-defined hot cue label prefixes in overview waveforms.

  BiteDJ defines Hot Cues 1–8 as A–H, but `WOverview::updateCues()` replaced those prefixes with
  the Mixxx default numeric labels. This caused the overview waveform to display `1`–`8` while
  the detailed waveform displayed `A`–`H`.

  ## Changes

  - Display A–H for Hot Cues 1–8 in overview waveforms
  - Display labels as `A: label` when a cue has a custom label
  - Preserve M1–M10 for memory cues
  - Preserve numeric fallback labels for marks without a skin-defined prefix

  ## Testing

  - `git diff --check`
  - Existing prefix fallback behavior was reviewed for explicitly defined and default marks

  A local build and runtime UI test were not performed because no configured build directory was
  available.