### PR TITLE
fix(waveform): use skin-defined hot cue labels in overview

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -512,12 +512,14 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
             if ((currentCue->getType() == mixxx::CueType::HotCue ||
                         currentCue->getType() == mixxx::CueType::Loop) &&
                     hotcueNumber != Cue::kNoHotCue) {
-                // Prepend the hotcue number to hotcues' labels
+                // Prepend the skin-defined hotcue prefix to hotcues' labels.
+                // This falls back to the hotcue number when no prefix is set.
                 QString newLabel = currentCue->getLabel();
                 if (newLabel.isEmpty()) {
-                    newLabel = QString::number(hotcueNumber + 1);
+                    newLabel = pMark->hotcueLabelPrefix();
                 } else {
-                    newLabel = QString("%1: %2").arg(hotcueNumber + 1).arg(newLabel);
+                    newLabel = QString("%1: %2")
+                                       .arg(pMark->hotcueLabelPrefix(), newLabel);
                 }
 
                 if (pMark->m_text != newLabel) {


### PR DESCRIPTION
## Summary

  Use the skin-defined hot cue label prefixes in overview waveforms.

  BiteDJ defines Hot Cues 1–8 as A–H, but `WOverview::updateCues()` replaced those prefixes with
  the Mixxx default numeric labels. This caused the overview waveform to display `1`–`8` while
  the detailed waveform displayed `A`–`H`.

<img width="1068" height="202" alt="スクリーンショット 2026-09-07 0 36 11" src="https://github.com/user-attachments/assets/0ac10f60-ff4a-4cb4-93d3-97b6019be5f5" />

  ## Changes

  - Display A–H for Hot Cues 1–8 in overview waveforms
  - Display labels as `A: label` when a cue has a custom label
  - Preserve M1–M10 for memory cues
  - Preserve numeric fallback labels for marks without a skin-defined prefix

  ## Testing

  - `git diff --check`
  - Existing prefix fallback behavior was reviewed for explicitly defined and default marks

  A local build and runtime UI test were not performed because no configured build directory was
  available.