### PR TITLE
fix(audio): hide ALSA logical devices

### DIFF
--- a/src/preferences/audiodevicesettings.cpp
+++ b/src/preferences/audiodevicesettings.cpp
@@ -696,6 +696,13 @@ void AudioDeviceSettings::refreshDeviceList() {
         if (pDevice->getDeviceId().name == kNetworkDeviceInternalName) {
             continue;
         }
+        // The appliance UI only supports direct ALSA hardware devices. Hide
+        // logical PCMs such as default, pulse, dmix, and surround aliases;
+        // SoundDevicePortAudio leaves alsaHwDevice empty for all of them.
+        if (pDevice->getHostAPI() == MIXXX_PORTAUDIO_ALSA_STRING &&
+                pDevice->getDeviceId().alsaHwDevice.isEmpty()) {
+            continue;
+        }
         const int channels = static_cast<int>(pDevice->getNumOutputChannels());
         if (channels < 2) {
             continue; // need at least stereo for a bus


### PR DESCRIPTION
## Summary

ALSA virtual devices were listed when selecting audio and headphone outputs. This change
  filters the list to show only physical devices


  ## Background

  PortAudio enumerates ALSA logical PCMs as audio devices. Some of these report
  large channel counts, causing unusable entries such as `DEFAULT CH15-16` to
  appear in BiteDJ's simplified audio settings.

  BiteDJ is intended to route audio directly to physical audio hardware, including
  USB audio interfaces, built-in audio devices, and HDMI outputs.

  ## Implementation

  When the selected host API is ALSA, output devices without an `alsaHwDevice`
  identifier are excluded from the BiteDJ audio device list. Existing handling
  for physical ALSA devices, non-ALSA devices, and the internal network stream is
  unchanged.

  Previously configured logical PCM devices no longer match a visible output and
  are treated as unconfigured.

  ## Validation

  - `git diff --check`
  - clang-format check for the changed lines
  - repository commit hooks